### PR TITLE
Add a bit delay

### DIFF
--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -54,6 +54,7 @@ Rapidfire::SendIndexCmd(uint8_t index)
     uint8_t newChannel = index % 8;
 
     SendBandCmd(newBand);
+	delay(100);
     SendChannelCmd(newChannel);
 }
 


### PR DESCRIPTION
Add a bit delay between SendBanchCmd() and SendChannelCmd() seems could improve rapidFIRE command response.