### PR TITLE
Add telemetry forward to another esp 

### DIFF
--- a/lib/MSP/msp.h
+++ b/lib/MSP/msp.h
@@ -4,9 +4,10 @@
 
 // TODO: MSP_PORT_INBUF_SIZE should be changed to
 // dynamically allocate array length based on the payload size
-// Hardcoding payload size to 8 bytes for now, since MSP is
-// limited to a 4 byte payload on the BF side
-#define MSP_PORT_INBUF_SIZE 8
+// Hardcoding payload size to 64 bytes for now, since 
+// MSP is limited to a 4 byte payload on the BF side, and
+// max crsf packet is 48 bytes so far (to accomodate crsf embeding). 
+#define MSP_PORT_INBUF_SIZE 64
 
 #define CHECK_PACKET_PARSING() \
   if (packet->readError) {\

--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -17,6 +17,9 @@
 #define MSP_ELRS_SET_TX_BACKPACK_WIFI_MODE      0x0C
 #define MSP_ELRS_SET_VRX_BACKPACK_WIFI_MODE     0x0D
 
+// msp encapsulated CRSF packet
+# define MSP_CRSF_PACKET                        0xFF01
+
 // CRSF encapsulated msp defines
 #define ENCAPSULATED_MSP_PAYLOAD_SIZE           4
 #define ENCAPSULATED_MSP_FRAME_LEN              8

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -134,6 +134,10 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     DBGLN("Processing MSP_ELRS_SET_TX_BACKPACK_WIFI_MODE...");
     RebootIntoWifi();
     break;
+  case MSP_CRSF_PACKET:
+    DBGLN("Processing MSP_CRSF_PACKET...");
+    sendMSPViaEspnow(packet);
+    break;
   default:
     break;
   }


### PR DESCRIPTION
Matching the expresslrs pr: https://github.com/ExpressLRS/ExpressLRS/pull/1107

Tested and works with HM ES24TX and another esp32 dev board that receives the telemetry. I haven't test it with another vrx. I'm not sure if using the same bound mac address is a problem. I will try it later. 