### PR TITLE
Don't init the VRX until the first VRX command

### DIFF
--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -44,6 +44,7 @@ unsigned long rebootTime = 0;
 uint8_t cachedIndex = 0;
 bool sendChangesToVrx = false;
 bool gotInitialPacket = false;
+bool initDone = false;
 uint32_t lastSentRequest = 0;
 
 device_t *ui_devices[] = {
@@ -322,7 +323,6 @@ void setup()
     esp_now_add_peer(broadcastAddress, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
     esp_now_register_recv_cb(OnDataRecv);
 
-    vrxModule.Init();
   }
 
   devicesStart();
@@ -359,6 +359,10 @@ void loop()
 
   if (sendChangesToVrx)
   {
+    if (!initDone){
+      vrxModule.Init();
+      initDone = true;
+    }
     sendChangesToVrx = false;
     vrxModule.SendIndexCmd(cachedIndex);
   }

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -44,7 +44,6 @@ unsigned long rebootTime = 0;
 uint8_t cachedIndex = 0;
 bool sendChangesToVrx = false;
 bool gotInitialPacket = false;
-bool initDone = false;
 uint32_t lastSentRequest = 0;
 
 device_t *ui_devices[] = {
@@ -323,6 +322,7 @@ void setup()
     esp_now_add_peer(broadcastAddress, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
     esp_now_register_recv_cb(OnDataRecv);
 
+    vrxModule.Init();
   }
 
   devicesStart();
@@ -359,10 +359,6 @@ void loop()
 
   if (sendChangesToVrx)
   {
-    if (!initDone){
-      vrxModule.Init();
-      initDone = true;
-    }
     sendChangesToVrx = false;
     vrxModule.SendIndexCmd(cachedIndex);
   }

--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -32,10 +32,6 @@ Rapidfire::EnableSPIMode()
     digitalWrite(PIN_CLK, LOW);
     digitalWrite(PIN_CS, LOW);
     delay(200);
-    
-    pinMode(PIN_MOSI, INPUT);
-    pinMode(PIN_CLK, INPUT);
-    pinMode(PIN_CS, INPUT);
 
     SPIModeEnabled = true;
 
@@ -45,21 +41,18 @@ Rapidfire::EnableSPIMode()
 void
 Rapidfire::SendBuzzerCmd()
 {
-    if (SPIModeEnabled)
-    {
-        DBGLN("Beep!");
-        
-        uint8_t cmd[4];
-        cmd[0] = RF_API_BEEP_CMD;   // 'S'
-        cmd[1] = RF_API_DIR_GRTHAN; // '>'
-        cmd[2] = 0x00;              // len
-        cmd[3] = crc8(cmd, 3);
+    DBGLN("Beep!");
+    
+    uint8_t cmd[4];
+    cmd[0] = RF_API_BEEP_CMD;   // 'S'
+    cmd[1] = RF_API_DIR_GRTHAN; // '>'
+    cmd[2] = 0x00;              // len
+    cmd[3] = crc8(cmd, 3);
 
-        // rapidfire sometimes missed a pkt, so send 3x
-        SendSPI(cmd, 4);
-        SendSPI(cmd, 4);
-        SendSPI(cmd, 4);
-    }
+    // rapidfire sometimes missed a pkt, so send 3x
+    SendSPI(cmd, 4);
+    SendSPI(cmd, 4);
+    SendSPI(cmd, 4);
 }
 
 void
@@ -165,9 +158,9 @@ Rapidfire::SendBandCmd(uint8_t band)
 void
 Rapidfire::SendSPI(uint8_t* buf, uint8_t bufLen)
 {
-    uint32_t periodMicroSec = 1000000 / BIT_BANG_FREQ;
-
     if (!SPIModeEnabled) EnableSPIMode();
+
+    uint32_t periodMicroSec = 1000000 / BIT_BANG_FREQ;
 
     pinMode(PIN_MOSI, OUTPUT);
     pinMode(PIN_CLK, OUTPUT);

--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -7,6 +7,12 @@ Rapidfire::Init()
 {
     delay(2000);  // wait for rapidfire to boot
 
+    DBGLN("Rapid Fire init");
+}
+
+void
+Rapidfire::EnableSPIMode()
+{
     // Set pins to output to configure rapidfire in SPI mode
     pinMode(PIN_MOSI, OUTPUT);
     pinMode(PIN_CLK, OUTPUT);
@@ -26,6 +32,8 @@ Rapidfire::Init()
     pinMode(PIN_MOSI, INPUT);
     pinMode(PIN_CLK, INPUT);
     pinMode(PIN_CS, INPUT);
+
+    SPIModeEnabled = true;
 
     DBGLN("SPI config complete");
 }
@@ -52,6 +60,8 @@ Rapidfire::SendIndexCmd(uint8_t index)
 {  
     uint8_t newBand = index / 8 + 1;
     uint8_t newChannel = index % 8;
+
+    if (!SPIModeEnabled) EnableSPIMode();
 
     SendBandCmd(newBand);
 	delay(100);

--- a/src/rapidfire.h
+++ b/src/rapidfire.h
@@ -22,5 +22,7 @@ public:
 
 private:
     void SendSPI(uint8_t* buf, uint8_t bufLen);
+    void EnableSPIMode();
     uint8_t crc8(uint8_t* buf, uint8_t bufLen);
+    bool SPIModeEnabled = false;
 };


### PR DESCRIPTION
This makes the module stay on the last know channel if the radio is off instead of changing to R8 (rapidfire)

If the radio is on or a lua command is sent it works as before.

This closes #42 

Edit: thinking about it this may not work well for other vrx modules. I only have the rapid fire to test with. Is it worth moving this into rapidfire.cpp?