### PR TITLE
RX5808 ESP-01f  Backpack Targets

### DIFF
--- a/src/rx5808.cpp
+++ b/src/rx5808.cpp
@@ -13,6 +13,11 @@ RX5808::Init()
     digitalWrite(PIN_CLK, LOW);
     digitalWrite(PIN_CS, HIGH);
 
+    #if defined(PIN_CS_2)
+        pinMode(PIN_CS_2, OUTPUT);
+        digitalWrite(PIN_CS_2, HIGH);
+    #endif
+
     DBGLN("SPI config complete");
 }
 
@@ -42,6 +47,9 @@ RX5808::rtc6705WriteRegister(uint32_t buf)
     uint32_t periodMicroSec = 1000000 / BIT_BANG_FREQ;
 
     digitalWrite(PIN_CS, LOW);
+    #if defined(PIN_CS_2)
+        digitalWrite(PIN_CS_2, LOW);
+    #endif
     delayMicroseconds(periodMicroSec);
 
     for (uint8_t i = 0; i < RX5808_PACKET_LENGTH; ++i)
@@ -61,6 +69,9 @@ RX5808::rtc6705WriteRegister(uint32_t buf)
     digitalWrite(PIN_MOSI, LOW);
     digitalWrite(PIN_CLK, LOW);
     digitalWrite(PIN_CS, HIGH);
+    #if defined(PIN_CS_2)
+        digitalWrite(PIN_CS_2, HIGH);
+    #endif
 }
 
 uint32_t

--- a/targets/diy_rx.ini
+++ b/targets/diy_rx.ini
@@ -16,3 +16,17 @@ build_flags =
 
 [env:Rapidfire_ESP01F_Backpack_via_WIFI]
 extends = env:Rapidfire_ESP01F_Backpack_via_UART
+
+[env:RX5808_ESP01F_Backpack_via_UART]
+extends = env_common_esp8285, rx5808_vrx_backpack_common
+build_flags =
+	${env_common_esp8285.build_flags}
+	${rx5808_vrx_backpack_common.build_flags}
+	-D PIN_BUTTON=0
+	-D PIN_LED=16
+	-D PIN_MOSI=13
+	-D PIN_CLK=14
+	-D PIN_CS=15
+
+[env:RX5808_ESP01F_Backpack_via_WIFI]
+extends = env:RX5808_ESP01F_Backpack_via_UART

--- a/targets/diy_rx.ini
+++ b/targets/diy_rx.ini
@@ -30,3 +30,12 @@ build_flags =
 
 [env:RX5808_ESP01F_Backpack_via_WIFI]
 extends = env:RX5808_ESP01F_Backpack_via_UART
+
+[env:RX5808_ESP01F_Diversity_Backpack_via_UART]
+extends = env:RX5808_ESP01F_Backpack_via_UART
+build_flags =
+	${env:RX5808_ESP01F_Backpack_via_UART.build_flags}
+	-D PIN_CS_2=5
+
+[env:RX5808_ESP01F_Diversity_Backpack_via_WIFI]
+extends = env:RX5808_ESP01F_Diversity_Backpack_via_UART


### PR DESCRIPTION
Add new targets for RX5808 modules

1. Add targets for RX5808_ESP01F_Backpack_via_UART and RX5808_ESP01F_Backpack_via_WIFI which allow the ESP-01F to be used as a backpack on RX5808 modules
2. Add targets for RX5808_ESP01F_Diversity_Backpack_via_UART and RX5808_ESP01F_Diversity_Backpack_via_WIFI which adds an extra CS pin that can be connected to the CS line on a second RX5808 module.  The extra CS pin is needed to control the second RX5808 module on goggles like the EV800D, tying the CS lines on the two modules together does not work, I was only able to get the backpack to control both modules with the use of a second CS pin going to the second module.

IO13 -> RX5808 <span>#</span>1 Ch1 (MOSI)
IO14 -> RX5808 <span>#</span>1 Ch3 (CLK)
IO15 -> RX5808 <span>#</span>1 Ch2 (CS)
IO5 -> RX5808 <span>#</span>2 Ch2 (CS)

ESP-01F wired into the EV800D goggles
![PXL_20220117_180810473 NIGHT](https://user-images.githubusercontent.com/38869875/150018509-4dd9424a-2e54-4097-ba9d-75e9f730bcfc.jpg)
