### PR TITLE
Create HappyModel EP82 VRX Target

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ extra_configs =
 	targets/diy_rx.ini
 	targets/generic_esp_rx.ini
 	targets/happymodel_tx.ini
+	targets/happymodel_vrx.ini
 	targets/namimnorc_tx.ini
 	targets/frsky_tx.ini
 	targets/fusion.ini

--- a/targets/happymodel_vrx.ini
+++ b/targets/happymodel_vrx.ini
@@ -1,0 +1,14 @@
+
+[env:Rapidfire_HappyModel_EP82_VRX_Backpack_via_UART]
+extends = env_common_esp8285, rapidfire_vrx_backpack_common
+build_flags =
+	${env_common_esp8285.build_flags}
+	${rapidfire_vrx_backpack_common.build_flags}
+	-D PIN_BUTTON=0
+	-D PIN_LED=16
+	-D PIN_MOSI=13
+	-D PIN_CLK=14
+	-D PIN_CS=15
+
+[env:Rapidfire_HappyModel_EP82_VRX_Backpack_via_WIFI]
+extends = env:Rapidfire_HappyModel_EP82_VRX_Backpack_via_UART


### PR DESCRIPTION
This is a source of continuing confusion for users trying to flash a VRX backpack. It makes some sense to use the HappyModel EP target for an EP82, but in fact, those pins will result in the module not booting. This creates a new target for clarity when flashing these devices.