### PR TITLE
Delay enabling of SPI on RX5808 until a command is received

### DIFF
--- a/src/rx5808.cpp
+++ b/src/rx5808.cpp
@@ -5,6 +5,20 @@
 void
 RX5808::Init()
 {
+    pinMode(PIN_MOSI, INPUT);
+    pinMode(PIN_CLK, INPUT);
+    pinMode(PIN_CS, INPUT);
+
+    #if defined(PIN_CS_2)
+        pinMode(PIN_CS_2, INPUT);
+    #endif
+
+    DBGLN("RX5808 init complete");
+}
+
+void
+RX5808::EnableSPIMode()
+{
     pinMode(PIN_MOSI, OUTPUT);
     pinMode(PIN_CLK, OUTPUT);
     pinMode(PIN_CS, OUTPUT);
@@ -18,12 +32,19 @@ RX5808::Init()
         digitalWrite(PIN_CS_2, HIGH);
     #endif
 
+    SPIModeEnabled = true;
+
     DBGLN("SPI config complete");
 }
 
 void
 RX5808::SendIndexCmd(uint8_t index)
 {
+    if (!SPIModeEnabled) 
+    {
+        EnableSPIMode();
+    }
+
     DBG("Setting index ");
     DBGLN("%x", index);
 

--- a/src/rx5808.cpp
+++ b/src/rx5808.cpp
@@ -40,11 +40,6 @@ RX5808::EnableSPIMode()
 void
 RX5808::SendIndexCmd(uint8_t index)
 {
-    if (!SPIModeEnabled) 
-    {
-        EnableSPIMode();
-    }
-
     DBG("Setting index ");
     DBGLN("%x", index);
 
@@ -65,6 +60,11 @@ RX5808::SendIndexCmd(uint8_t index)
 void
 RX5808::rtc6705WriteRegister(uint32_t buf)
 {
+    if (!SPIModeEnabled) 
+    {
+        EnableSPIMode();
+    }
+
     uint32_t periodMicroSec = 1000000 / BIT_BANG_FREQ;
 
     digitalWrite(PIN_CS, LOW);
@@ -98,6 +98,11 @@ RX5808::rtc6705WriteRegister(uint32_t buf)
 uint32_t
 RX5808::rtc6705readRegister(uint8_t readRegister)
 {
+    if (!SPIModeEnabled) 
+    {
+        EnableSPIMode();
+    }
+
     uint32_t buf = readRegister | (RX5808_READ_CTRL_BIT << 4);
     uint32_t registerData = 0;
 

--- a/src/rx5808.h
+++ b/src/rx5808.h
@@ -41,4 +41,6 @@ public:
 private:
     void rtc6705WriteRegister(uint32_t buf);
     uint32_t rtc6705readRegister(uint8_t readRegister);
+    void EnableSPIMode();
+    bool SPIModeEnabled = false;
 };


### PR DESCRIPTION
By setting the SPI pins into output mode after a command is received, the buttons on the device (handheld FPV viewers, goggles, etc.) can be used as normal to change channels until a TX backpack commands a channel change.  This allows RX5808 devices to be used for spectating and with non-ELRS models without the backpack always taking control.