### PR TITLE
Add ESP12F target

### DIFF
--- a/targets/common.ini
+++ b/targets/common.ini
@@ -23,15 +23,6 @@ board_build.f_cpu = 160000000L
 build_flags =
 	-D PLATFORM_ESP8266=1
 
-# ------------------------- COMMON ESP8266 DEFINITIONS -----------------
-[env_common_esp8266]
-board = esp12e
-board_build.ldscript = eagle.flash.1m144.ld
-upload_speed = 921600
-monitor_speed = 460800
-board_build.f_cpu = 160000000L
-build_flags =
-	-D PLATFORM_ESP8266=1
 
 # ------------------------- COMMON ESP12E DEFINITIONS -----------------
 [env_common_esp12e]

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -23,7 +23,6 @@ board_build.f_cpu = 160000000L
 build_flags =
 	-D PLATFORM_ESP8266=1
 
-
 # ------------------------- COMMON ESP12E DEFINITIONS -----------------
 [env_common_esp12e]
 board = esp12e

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -23,6 +23,16 @@ board_build.f_cpu = 160000000L
 build_flags =
 	-D PLATFORM_ESP8266=1
 
+# ------------------------- COMMON ESP8266 DEFINITIONS -----------------
+[env_common_esp8266]
+board = esp12e
+board_build.ldscript = eagle.flash.1m144.ld
+upload_speed = 921600
+monitor_speed = 460800
+board_build.f_cpu = 160000000L
+build_flags =
+	-D PLATFORM_ESP8266=1
+
 # ------------------------- COMMON ESP12E DEFINITIONS -----------------
 [env_common_esp12e]
 board = esp12e

--- a/targets/diy_rx.ini
+++ b/targets/diy_rx.ini
@@ -39,3 +39,33 @@ build_flags =
 
 [env:RX5808_ESP01F_Diversity_Backpack_via_WIFI]
 extends = env:RX5808_ESP01F_Diversity_Backpack_via_UART
+
+[env:RX5808_ESP12F_Backpack_via_UART]
+extends = env_common_esp8266, rx5808_vrx_backpack_common
+build_flags =
+	${env_common_esp8266.build_flags}
+	${rx5808_vrx_backpack_common.build_flags}
+	-D LED_INVERTED
+	-D PIN_BUTTON=0
+	-D PIN_LED=2
+	-D PIN_MOSI=13
+	-D PIN_CLK=14
+	-D PIN_CS=12
+
+[env:RX5808_ESP12F_Backpack_via_WIFI]
+extends = env:RX5808_ESP12F_Backpack_via_UART
+
+[env:Rapidfire_ESP12F_Backpack_via_UART]
+extends = env_common_esp8266, rapidfire_vrx_backpack_common
+build_flags =
+	${env_common_esp8266.build_flags}
+	${rapidfire_vrx_backpack_common.build_flags}
+	-D LED_INVERTED
+	-D PIN_BUTTON=0
+	-D PIN_LED=2
+	-D PIN_MOSI=13
+	-D PIN_CLK=14
+	-D PIN_CS=12
+
+[env:Rapidfire_ESP12F_Backpack_via_WIFI]
+extends = env:Rapidfire_ESP12F_Backpack_via_UART

--- a/targets/diy_rx.ini
+++ b/targets/diy_rx.ini
@@ -41,9 +41,9 @@ build_flags =
 extends = env:RX5808_ESP01F_Diversity_Backpack_via_UART
 
 [env:RX5808_ESP12F_Backpack_via_UART]
-extends = env_common_esp8266, rx5808_vrx_backpack_common
+extends = env_common_esp12e, rx5808_vrx_backpack_common
 build_flags =
-	${env_common_esp8266.build_flags}
+	${env_common_esp12e.build_flags}
 	${rx5808_vrx_backpack_common.build_flags}
 	-D LED_INVERTED
 	-D PIN_BUTTON=0
@@ -56,9 +56,9 @@ build_flags =
 extends = env:RX5808_ESP12F_Backpack_via_UART
 
 [env:Rapidfire_ESP12F_Backpack_via_UART]
-extends = env_common_esp8266, rapidfire_vrx_backpack_common
+extends = env_common_esp12e, rapidfire_vrx_backpack_common
 build_flags =
-	${env_common_esp8266.build_flags}
+	${env_common_esp12e.build_flags}
 	${rapidfire_vrx_backpack_common.build_flags}
 	-D LED_INVERTED
 	-D PIN_BUTTON=0


### PR DESCRIPTION
This adds the ESP12F modules as a VRX backpack target as well as fix the LED inversion code as this module uses a inverted built-in LED.
![ESP12F Wiring Diagram](https://yamato.azurlane.moe/media/m3vpa.png)

This module will also require a 5V to 3v3 regulator to work.