### PR TITLE
Drop renaming of firmware.bin for Gen1 Namimno TX Backpack

### DIFF
--- a/python/rename_bin.py
+++ b/python/rename_bin.py
@@ -1,2 +1,0 @@
-Import("env")
-env.Replace(PROGNAME="backpack")

--- a/targets/namimnorc_tx.ini
+++ b/targets/namimnorc_tx.ini
@@ -12,7 +12,6 @@ build_flags =
 	-D PIN_LED=16
 extra_scripts =
 	${env.extra_scripts}
-	pre:python/rename_bin.py
 
 [env:NamimnoRC_TX_Backpack_via_WIFI]
 extends = env:NamimnoRC_TX_Backpack_via_UART


### PR DESCRIPTION
"Build and Flash" via ExpressLRS Configurator for the Gen1 Namimno TX Backpack isn't working.
![NamTXBPBuildandFlash](https://user-images.githubusercontent.com/83231715/153352018-670da8e2-f285-472c-8657-0124e552e967.jpg)

Same issue with Upload with PlatformIO.
This is because the script upload_via_esp8266_backpack.py looks for firmware.bin instead of backpack.bin.

I think renaming this file is no longer needed since the WiFi Update page File Upload form no longer needs it named as "backpack.bin". We can also now upload the target_name.bin files.