### PR TITLE
force EnableSPIMode() on boot

### DIFF
--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -7,8 +7,8 @@ Rapidfire::Init()
 {
     delay(VRX_BOOT_DELAY);
 
-    EnableSPIMode();
-    
+    EnableSPIMode(); // https://github.com/ExpressLRS/ExpressLRS/pull/1489 & https://github.com/ExpressLRS/Backpack/pull/65
+
     pinMode(PIN_MOSI, INPUT);
     pinMode(PIN_CLK, INPUT);
     pinMode(PIN_CS, INPUT);

--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -5,11 +5,13 @@
 void
 Rapidfire::Init()
 {
+    delay(VRX_BOOT_DELAY);
+
+    EnableSPIMode();
+    
     pinMode(PIN_MOSI, INPUT);
     pinMode(PIN_CLK, INPUT);
     pinMode(PIN_CS, INPUT);
-
-    delay(VRX_BOOT_DELAY);
 
     DBGLN("Rapid Fire init");
 }


### PR DESCRIPTION
This PR reverts PR https://github.com/ExpressLRS/Backpack/pull/44

@Aaronsss Im forcing SPI Mode on boot again.  If the tx decides to send a command to the VRx mid flight after a tlm lost/recovered moment, then SPI Mode can be activated.  With RF this flashes up the OSD menu :expressionless:

Example DVR https://streamable.com/egdng8