### PR TITLE
Passthrough flashing

### DIFF
--- a/targets/dupletx_tx.ini
+++ b/targets/dupletx_tx.ini
@@ -20,5 +20,5 @@ extends = env:DUPLETX_TX_Backpack_via_UART
 
 [env:DUPLETX_TX_Backpack_via_PASSTHRU]
 extends = env:DUPLETX_TX_Backpack_via_UART
-upload_speed = 115200
+upload_speed = 230400
 upload_command = python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before passthru --after soft_reset write_flash 0x0000 "$SOURCE"

--- a/targets/dupletx_tx.ini
+++ b/targets/dupletx_tx.ini
@@ -17,3 +17,8 @@ extends = env:DUPLETX_TX_Backpack_via_UART
 
 [env:DUPLETX_TX_Backpack_via_WIFI]
 extends = env:DUPLETX_TX_Backpack_via_UART
+
+[env:DUPLETX_TX_Backpack_via_PASSTHRU]
+extends = env:DUPLETX_TX_Backpack_via_UART
+upload_speed = 115200
+upload_command = python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before passthru --after soft_reset write_flash 0x0000 "$SOURCE"

--- a/targets/happymodel_tx.ini
+++ b/targets/happymodel_tx.ini
@@ -12,3 +12,8 @@ build_flags =
 
 [env:HappyModel_TX_Backpack_via_WIFI]
 extends = env:HappyModel_TX_Backpack_via_UART
+
+[env:HappyModel_TX_Backpack_via_PASSTHRU]
+extends = env:HappyModel_TX_Backpack_via_UART
+upload_speed = 115200
+upload_command = python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before passthru --after soft_reset write_flash 0x0000 "$SOURCE"

--- a/targets/happymodel_tx.ini
+++ b/targets/happymodel_tx.ini
@@ -15,5 +15,5 @@ extends = env:HappyModel_TX_Backpack_via_UART
 
 [env:HappyModel_TX_Backpack_via_PASSTHRU]
 extends = env:HappyModel_TX_Backpack_via_UART
-upload_speed = 115200
+upload_speed = 230400
 upload_command = python "$PROJECT_DIR/python/esptool-3.0/esptool.py" -b $UPLOAD_SPEED ${UPLOAD_PORT and "-p "+UPLOAD_PORT} -c esp8266 --before passthru --after soft_reset write_flash 0x0000 "$SOURCE"


### PR DESCRIPTION
Allow passthrough flashing of the backpack if it is NOT connected UART0 and has the EN/BOOT pins connected.
This also supports modules connected via s.port where UART0 is only used for flashing.