### PR TITLE
Fix odd binding behaviour

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -11,3 +11,5 @@ typedef enum
 
 extern connectionState_e connectionState;
 extern unsigned long bindingStart;
+
+#define UID_SIZE 6


### PR DESCRIPTION
There is a weird bind behaviour on the TX backpack.

# Problem
The TX backpack on receiving a bind message from the TX module, stores the UID and forwards the bind message, via ESPnow, to any listening VRx backpacks. The problem is that if the TX backpack is flashed with a passphrase it will always use the flashed UID as the ESPnow group address. So the upshot is that the VRx has bound to the TX address, not the TX backpack address.

# Solution
~When sending a bind from the TX backpack, if the backpack was flashed with a passphrase, overwrite the address in the message with the flashed address.~

EDIT:
After discussions, we now check the flashed UID against the passed in binding UID. If they are different then drop the bind, and print an error message. If there is no flashed UID, store the passed in binding UID as the UID for the TX backpack and forward it on to continue the binding process.

The downside to this is that the TX backpack will not bind if it flashed with a different bind-phrase to the TX module. Which is probably better than binding and not working.
