### PR TITLE
Fix MSP usage error

### DIFF
--- a/src/hdzero.cpp
+++ b/src/hdzero.cpp
@@ -39,6 +39,7 @@ HDZero::GetChannelIndex()
     if (receivedResponse)
     {
         packet = msp.getReceivedPacket();
+        msp.markPacketReceived();
         return packet->readByte();
     }
 
@@ -74,6 +75,7 @@ HDZero::GetRecordingState()
     if (receivedResponse)
     {
         packet = msp.getReceivedPacket();
+        msp.markPacketReceived();
         return packet->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
     }
 

--- a/src/skyzone_msp.cpp
+++ b/src/skyzone_msp.cpp
@@ -16,7 +16,7 @@ SkyzoneMSP::Init()
 
 void
 SkyzoneMSP::SendIndexCmd(uint8_t index)
-{  
+{
     uint8_t retries = 3;
     while (GetChannelIndex() != index && retries > 0)
     {
@@ -40,6 +40,7 @@ SkyzoneMSP::GetChannelIndex()
     if (receivedResponse)
     {
         packet = msp.getReceivedPacket();
+        msp.markPacketReceived();
         return packet->readByte();
     }
 
@@ -49,7 +50,7 @@ SkyzoneMSP::GetChannelIndex()
 
 void
 SkyzoneMSP::SetChannelIndex(uint8_t index)
-{  
+{
     MSP msp;
     mspPacket_t packet;
     packet.reset();
@@ -87,7 +88,7 @@ void
 SkyzoneMSP::SetRecordingState(uint8_t recordingState, uint16_t delay)
 {
     DBGLN("SetRecordingState = %d delay = %d", recordingState, delay);
-    
+
     m_recordingState = recordingState;
     m_delay = delay * 1000; // delay is in seconds, convert to milliseconds
     m_delayStartMillis = millis();
@@ -102,7 +103,7 @@ void
 SkyzoneMSP::SendRecordingState()
 {
     DBGLN("SendRecordingState = %d delay = %d", m_recordingState, m_delay);
-    
+
     MSP msp;
     mspPacket_t packet;
     packet.reset();

--- a/src/skyzone_msp.cpp
+++ b/src/skyzone_msp.cpp
@@ -75,6 +75,7 @@ SkyzoneMSP::GetRecordingState()
     if (receivedResponse)
     {
         packet = msp.getReceivedPacket();
+        msp.markPacketReceived();
         return packet->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
     }
 


### PR DESCRIPTION
Fixes an error where the hdzero and skyzone backpacks would read a MSP message (response) from the VRx and would not mark the message as received. This then left the MSP processor in the RECEIVED state. The next character pushed into the processor would be ignored, but put it into IDLE state, so the next whole message is discarded.

This manifests itself as alternate message would be processed.