### PR TITLE
Add RX5808 with HappyModel_EP82

### DIFF
--- a/targets/happymodel_vrx.ini
+++ b/targets/happymodel_vrx.ini
@@ -12,3 +12,17 @@ build_flags =
 
 [env:Rapidfire_HappyModel_EP82_VRX_Backpack_via_WIFI]
 extends = env:Rapidfire_HappyModel_EP82_VRX_Backpack_via_UART
+
+[env:RX5808_HappyModel_EP82_VRX_Backpack_via_UART]
+extends = env_common_esp8285, rx5808_vrx_backpack_common
+build_flags =
+	${env_common_esp8285.build_flags}
+	${rx5808_vrx_backpack_common.build_flags}
+	-D PIN_BUTTON=0
+	-D PIN_LED=16
+	-D PIN_MOSI=13
+	-D PIN_CLK=14
+	-D PIN_CS=15
+
+[env:RX5808_HappyModel_EP82_VRX_Backpack_via_WIFI]
+extends = env:RX5808_HappyModel_EP82_VRX_Backpack_via_UART


### PR DESCRIPTION
Problem: 
We only have RapidFire target for HappyModel EP82
I tried to replace my Happymodel EP2 in VRX backpak with EP82 and it didn't work with existing targets.
