### PR TITLE
Fix initialisation delay

### DIFF
--- a/src/fusion.h
+++ b/src/fusion.h
@@ -3,7 +3,6 @@
 #include "module_base.h"
 #include <Arduino.h>
 
-#undef VRX_BOOT_DELAY
 #define VRX_BOOT_DELAY  1000
 
 #define VRX_UART_BAUD   500000   // fusion uses 500k baud between the ESP8266 and the STM32

--- a/src/hdzero.h
+++ b/src/hdzero.h
@@ -5,7 +5,6 @@
 #include "module_base.h"
 #include <Arduino.h>
 
-#undef VRX_BOOT_DELAY
 #define VRX_BOOT_DELAY              7000
 
 #define VRX_RESPONSE_TIMEOUT        500

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -3,7 +3,6 @@
 void
 ModuleBase::Init()
 {
-    delay(VRX_BOOT_DELAY);
 }
 
 void

--- a/src/module_base.h
+++ b/src/module_base.h
@@ -2,8 +2,6 @@
 
 #include <Arduino.h>
 
-#define VRX_BOOT_DELAY  0
-
 class ModuleBase
 {
 public:

--- a/src/rapidfire.cpp
+++ b/src/rapidfire.cpp
@@ -7,6 +7,7 @@ Rapidfire::Init()
 {
     ModuleBase::Init();
 
+    delay(VRX_BOOT_DELAY);
     EnableSPIMode(); // https://github.com/ExpressLRS/ExpressLRS/pull/1489 & https://github.com/ExpressLRS/Backpack/pull/65
 
     pinMode(PIN_MOSI, INPUT);
@@ -44,7 +45,7 @@ void
 Rapidfire::SendBuzzerCmd()
 {
     DBGLN("Beep!");
-    
+
     uint8_t cmd[4];
     cmd[0] = RF_API_BEEP_CMD;   // 'S'
     cmd[1] = RF_API_DIR_GRTHAN; // '>'
@@ -59,7 +60,7 @@ Rapidfire::SendBuzzerCmd()
 
 void
 Rapidfire::SendIndexCmd(uint8_t index)
-{  
+{
     uint8_t newBand = index / 8 + 1;
     uint8_t newChannel = index % 8;
 
@@ -194,7 +195,7 @@ Rapidfire::SendSPI(uint8_t* buf, uint8_t bufLen)
             digitalWrite(PIN_CLK, HIGH);
             delayMicroseconds(periodMicroSec / 2);
 
-            bufByte <<= 1; 
+            bufByte <<= 1;
         }
     }
     DBGLN("");
@@ -203,7 +204,7 @@ Rapidfire::SendSPI(uint8_t* buf, uint8_t bufLen)
     digitalWrite(PIN_CLK, LOW);
     digitalWrite(PIN_CS, HIGH);
     delay(100);
-    
+
     pinMode(PIN_MOSI, INPUT);
     pinMode(PIN_CLK, INPUT);
     pinMode(PIN_CS, INPUT);

--- a/src/rapidfire.h
+++ b/src/rapidfire.h
@@ -3,7 +3,6 @@
 #include "module_base.h"
 #include <Arduino.h>
 
-#undef VRX_BOOT_DELAY
 #define VRX_BOOT_DELAY  2000
 
 #define BIT_BANG_FREQ       1000

--- a/src/skyzone_msp.h
+++ b/src/skyzone_msp.h
@@ -5,7 +5,6 @@
 #include "module_base.h"
 #include <Arduino.h>
 
-#undef VRX_BOOT_DELAY
 #define VRX_BOOT_DELAY              2000
 
 #define VRX_RESPONSE_TIMEOUT        500


### PR DESCRIPTION
A user was updating the rapidfire backpack and notice that the device would not enter SPI mode unless the EP82 button was held down.
Investigation shows that the init delay was broken as part of the refactoring in 1.2 to create a base class for modules.
This PR allows each module class to provide a boot delay, which the base class uses at initialisation time.