### PR TITLE
Wireless Head Tracking

### DIFF
--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -26,6 +26,8 @@
 
 // ELRS backpack protocol opcodes
 // See: https://docs.google.com/document/d/1u3c7OTiO4sFL2snI-hIo-uRSLfgBK4h16UrbA08Pd6U/edit#heading=h.1xw7en7jmvsj
+
+// outgoing, packets originating from the backpack or forwarded from the TX backpack to the VRx
 #define MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX     0x0300
 #define MSP_ELRS_BACKPACK_SET_CHANNEL_INDEX     0x0301
 #define MSP_ELRS_BACKPACK_GET_FREQUENCY         0x0302
@@ -39,7 +41,10 @@
 #define MSP_ELRS_BACKPACK_GET_FIRMWARE          0x030A
 #define MSP_ELRS_BACKPACK_SET_BUZZER            0x030B
 #define MSP_ELRS_BACKPACK_SET_OSD_ELEMENT       0x030C
-#define MSP_ELRS_BACKPACK_SET_MODE              0x0380
-#define MSP_ELRS_BACKPACK_GET_VERSION           0x0381
-#define MSP_ELRS_BACKPACK_GET_STATUS            0x0382
-#define MSP_ELRS_BACKPACK_SET_PTR               0x0383
+#define MSP_ELRS_BACKPACK_SET_HEAD_TRACKING     0x030D  // enable/disable head-tracking forwarding packets to the TX
+
+// incoming, packets originating from the VRx
+#define MSP_ELRS_BACKPACK_SET_MODE              0x0380  // enable wifi/binding mode
+#define MSP_ELRS_BACKPACK_GET_VERSION           0x0381  // get the bacpack firmware version
+#define MSP_ELRS_BACKPACK_GET_STATUS            0x0382  // get the status of the backpack
+#define MSP_ELRS_BACKPACK_SET_PTR               0x0383  // forwarded back to TX backpack

--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -42,3 +42,4 @@
 #define MSP_ELRS_BACKPACK_SET_MODE              0x0380
 #define MSP_ELRS_BACKPACK_GET_VERSION           0x0381
 #define MSP_ELRS_BACKPACK_GET_STATUS            0x0382
+#define MSP_ELRS_BACKPACK_SET_PTR               0x0383

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -179,7 +179,6 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
     cachedHTPacket = *packet;
     cacheFull = true;
-    // transparently forward MSP packets via espnow to any subscribers
     sendMSPViaEspnow(packet);
     break;
   default:

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -71,6 +71,10 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
       sendCached = true;
     }
   }
+  else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR)
+  {
+    msp.sendPacket(packet, &Serial);
+  }
 }
 
 // espnow on-receive callback

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -45,6 +45,7 @@ MSP msp;
 ELRS_EEPROM eeprom;
 TxBackpackConfig config;
 mspPacket_t cachedVTXPacket;
+mspPacket_t cachedHTPacket;
 
 /////////// FUNCTION DEFS ///////////
 
@@ -73,6 +74,7 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
   }
   else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR)
   {
+    DBGLN("MSP_ELRS_BACKPACK_SET_PTR...");
     msp.sendPacket(packet, &Serial);
   }
 }
@@ -138,6 +140,13 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     DBGLN("Processing MSP_ELRS_SET_TX_BACKPACK_WIFI_MODE...");
     RebootIntoWifi();
     break;
+  case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
+    cachedHTPacket = *packet;
+    cacheFull = true;
+    // transparently forward MSP packets via espnow to any subscribers
+    sendMSPViaEspnow(packet);
+    break;
   default:
     // transparently forward MSP packets via espnow to any subscribers
     sendMSPViaEspnow(packet);
@@ -178,7 +187,14 @@ void SendCachedMSP()
     return;
   }
 
-  sendMSPViaEspnow(&cachedVTXPacket);
+  if (cachedVTXPacket.type != MSP_PACKET_UNKNOWN)
+  {
+    sendMSPViaEspnow(&cachedVTXPacket);
+  }
+  if (cachedHTPacket.type != MSP_PACKET_UNKNOWN)
+  {
+    sendMSPViaEspnow(&cachedHTPacket);
+  }
 }
 
 void SetSoftMACAddress()

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -69,6 +69,7 @@ unsigned long rebootTime = 0;
 uint8_t cachedIndex = 0;
 bool sendChangesToVrx = false;
 bool gotInitialPacket = false;
+bool headTrackingEnabled = false;
 uint32_t lastSentRequest = 0;
 
 device_t *ui_devices[] = {
@@ -221,6 +222,10 @@ void ProcessMSPPacket(mspPacket_t *packet)
       uint16_t delay = lowByte | highByte << 8;
       vrxModule.SetRecordingState(state, delay);
     }
+    break;
+  case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
+    headTrackingEnabled = packet->readByte();
     break;
   default:
     DBGLN("Unknown command from ESPNOW");

--- a/src/hdzero.cpp
+++ b/src/hdzero.cpp
@@ -95,3 +95,16 @@ HDZero::SetRecordingState(uint8_t recordingState, uint16_t delay)
 
     msp.sendPacket(&packet, m_port);
 }
+
+void
+HDZero::SendHeadTrackingEnableCmd(bool enable)
+{
+    MSP msp;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_SET_HEAD_TRACKING;
+    packet.addByte(enable);
+
+    msp.sendPacket(&packet, m_port);
+}

--- a/src/hdzero.h
+++ b/src/hdzero.h
@@ -24,4 +24,5 @@ public:
     void SetChannelIndex(uint8_t index);
     uint8_t GetRecordingState();
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
+    void SendHeadTrackingEnableCmd(bool enable);
 };

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -29,6 +29,11 @@ ModuleBase::SetRecordingState(uint8_t recordingState, uint16_t delay)
 }
 
 void
+ModuleBase::SendHeadTrackingEnableCmd(bool enable)
+{
+}
+
+void
 ModuleBase::Loop(uint32_t now)
 {
 }

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -9,6 +9,7 @@ void RebootIntoWifi();
 bool BindingExpired(uint32_t now);
 extern uint8_t backpackVersion[];
 extern uint8_t broadcastAddress[6];
+void sendMSPViaEspnow(mspPacket_t *packet);
 
 void
 ModuleBase::Init()
@@ -91,6 +92,10 @@ MSPModuleBase::Loop(uint32_t now)
                 response[0] |= memcmp(broadcastAddress, unbound, 6) != 0 ? 4 : 0;
                 memcpy(&response[1], broadcastAddress, 6);
                 sendResponse(MSP_ELRS_BACKPACK_GET_STATUS, response, sizeof(response));
+            }
+            else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR)
+            {
+                  sendMSPViaEspnow(packet);
             }
             msp.markPacketReceived();
         }

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -9,6 +9,7 @@ void RebootIntoWifi();
 bool BindingExpired(uint32_t now);
 extern uint8_t backpackVersion[];
 extern uint8_t broadcastAddress[6];
+extern bool headTrackingEnabled;
 void sendMSPViaEspnow(mspPacket_t *packet);
 
 void
@@ -93,7 +94,7 @@ MSPModuleBase::Loop(uint32_t now)
                 memcpy(&response[1], broadcastAddress, 6);
                 sendResponse(MSP_ELRS_BACKPACK_GET_STATUS, response, sizeof(response));
             }
-            else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR)
+            else if (packet->function == MSP_ELRS_BACKPACK_SET_PTR && headTrackingEnabled)
             {
                   sendMSPViaEspnow(packet);
             }

--- a/src/module_base.h
+++ b/src/module_base.h
@@ -11,6 +11,7 @@ public:
     void Init();
     void SendIndexCmd(uint8_t index);
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
+    void SendHeadTrackingEnableCmd(bool enable);
     void Loop(uint32_t now);
 };
 

--- a/src/skyzone_msp.cpp
+++ b/src/skyzone_msp.cpp
@@ -11,7 +11,7 @@ SkyzoneMSP::Init()
 
 void
 SkyzoneMSP::SendIndexCmd(uint8_t index)
-{  
+{
     uint8_t retries = 3;
     while (GetChannelIndex() != index && retries > 0)
     {
@@ -35,6 +35,7 @@ SkyzoneMSP::GetChannelIndex()
     if (receivedResponse)
     {
         packet = msp.getReceivedPacket();
+        msp.markPacketReceived();
         return packet->readByte();
     }
 
@@ -44,7 +45,7 @@ SkyzoneMSP::GetChannelIndex()
 
 void
 SkyzoneMSP::SetChannelIndex(uint8_t index)
-{  
+{
     MSP msp;
     mspPacket_t packet;
     packet.reset();
@@ -82,7 +83,7 @@ void
 SkyzoneMSP::SetRecordingState(uint8_t recordingState, uint16_t delay)
 {
     DBGLN("SetRecordingState = %d delay = %d", recordingState, delay);
-    
+
     m_recordingState = recordingState;
     m_delay = delay * 1000; // delay is in seconds, convert to milliseconds
     m_delayStartMillis = millis();
@@ -97,7 +98,7 @@ void
 SkyzoneMSP::SendRecordingState()
 {
     DBGLN("SendRecordingState = %d delay = %d", m_recordingState, m_delay);
-    
+
     MSP msp;
     mspPacket_t packet;
     packet.reset();
@@ -106,6 +107,19 @@ SkyzoneMSP::SendRecordingState()
     packet.addByte(m_recordingState);
     packet.addByte(m_delay & 0xFF); // delay byte 1
     packet.addByte(m_delay >> 8); // delay byte 2
+
+    msp.sendPacket(&packet, m_port);
+}
+
+void
+SkyzoneMSP::SendHeadTrackingEnableCmd(bool enable)
+{
+    MSP msp;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_SET_HEAD_TRACKING;
+    packet.addByte(enable);
 
     msp.sendPacket(&packet, m_port);
 }

--- a/src/skyzone_msp.h
+++ b/src/skyzone_msp.h
@@ -26,6 +26,7 @@ public:
     void SetChannelIndex(uint8_t index);
     uint8_t GetRecordingState();
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
+    void SendHeadTrackingEnableCmd(bool enable);
     void Loop(uint32_t now);
 
 private:


### PR DESCRIPTION
This PR builds on top of #73 and #75

It adds a command to enable head-tracking on the VRx (goggles) and also forwards head tracking packets back to the TX module for merging into the channel data sent to the RX.

To test this PR you currently need to have the HDzero backpack and TX backpack flashed with this PR, the HDzero goggles flashed with wireless head-tracking PR (https://github.com/hd-zero/hdzero-goggle/pull/135) and the TX module flashed with the wireless head tracking PR (https://github.com/ExpressLRS/ExpressLRS/pull/2060).