### PR TITLE
Clock update via NTP & Platform update

### DIFF
--- a/html/scan.js
+++ b/html/scan.js
@@ -13,6 +13,7 @@ function get_mode() {
             var data = JSON.parse(this.responseText);
             if (data.mode==="STA") {
                 _('stamode').style.display = 'block';
+                _('rtctab').style.display = 'block';
                 _('ssid').textContent = data.ssid;
             } else {
                 _('apmode').style.display = 'block';
@@ -347,6 +348,9 @@ _('forget').addEventListener('click', callback("Forget Home Network", "An error 
 if (_('modelmatch') != undefined) {
     _('modelmatch').addEventListener('submit', callback("Set Model Match", "An error occurred updating the model match number", "/model", null));
 }
+_('setrtc').addEventListener('submit', callback("Set RTC Time", "An error occured setting the RTC time", "/setrtc", function() {
+    return new FormData(_('setrtc'));
+}));
 
 //=========================================================
 

--- a/html/vrx_index.html
+++ b/html/vrx_index.html
@@ -27,6 +27,7 @@
 			<ul class="mui-tabs__bar mui-tabs__bar--justified">
 				<li class="mui--is-active"><a data-mui-toggle="tab" data-mui-controls="pane-justified-1">Update</a></li>
 				<li><a data-mui-toggle="tab" data-mui-controls="pane-justified-2">Network</a></li>
+				<li id="rtctab" style="display:none;"><a data-mui-toggle="tab" data-mui-controls="pane-justified-3">RTC Time</a></li>
 			</ul>
 
 			<div class="mui-tabs__pane mui--is-active" id="pane-justified-1">
@@ -79,6 +80,29 @@
 					Disconnect from &quot;home&quot; network start access point
 					<br>
 					<a id="access" href="#" class="mui-btn mui-btn--primary">Disconnect</a>
+				</div>
+			</div>
+
+			<div class="mui-tabs__pane" id="pane-justified-3">
+				<div class="mui-panel">
+					<h2>RTC Update via NTP</h2>
+					Here you can update your goggle RTC clock time using any available NTP server.
+					Make sure that the home network you're connected to has access to the Internet in order to connect to the NTP server.
+					<form action="/setrtc" id="setrtc" method="POST" class="mui-form">
+						<div class="mui-textfield" style="width: 50%;">
+							<input id="server" type="text" name="server" placeholder="NTP Server"/>
+						</div>
+						<div class="mui-textfield" style="width: 50%;">
+							<input id="offset" type="number" name="offset" min="-12" max="12" placeholder="UTC Offset"/>
+						</div>
+						<div class="mui-checkbox">
+							<label>
+								<input id="dst" type="checkbox" name="dst">
+								Daylight Saving
+							</label>
+						</div>
+						<input type="submit" value="Set Time" class="mui-btn mui-btn--primary">
+					</form>
 				</div>
 			</div>
 		</div>

--- a/html/vrx_index.html
+++ b/html/vrx_index.html
@@ -90,14 +90,14 @@
 					Make sure that the home network you're connected to has access to the Internet in order to connect to the NTP server.
 					<form action="/setrtc" id="setrtc" method="POST" class="mui-form">
 						<div class="mui-textfield" style="width: 50%;">
-							<input id="server" type="text" name="server" placeholder="NTP Server"/>
+							<input id="server" type="text" name="server" value="pool.ntp.org"/>
 						</div>
 						<div class="mui-textfield" style="width: 50%;">
 							<input id="offset" type="number" name="offset" min="-12" max="12" placeholder="UTC Offset"/>
 						</div>
 						<div class="mui-checkbox">
 							<label>
-								<input id="dst" type="checkbox" name="dst">
+								<input id="dst" type="checkbox" name="dst" checked>
 								Daylight Saving
 							</label>
 						</div>

--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -43,6 +43,7 @@
 #define MSP_ELRS_BACKPACK_SET_BUZZER            0x030B
 #define MSP_ELRS_BACKPACK_SET_OSD_ELEMENT       0x030C
 #define MSP_ELRS_BACKPACK_SET_HEAD_TRACKING     0x030D  // enable/disable head-tracking forwarding packets to the TX
+#define MSP_ELRS_BACKPACK_SET_RTC               0x030E
 
 // incoming, packets originating from the VRx
 #define MSP_ELRS_BACKPACK_SET_MODE              0x0380  // enable wifi/binding mode

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -432,7 +432,9 @@ static void WebUploadRTCUpdateHandler(AsyncWebServerRequest *request) {
 
   DBGLN("Getting NTP data from %s", ntpServer.c_str());
   configTime(dst, utcOffset, ntpServer.c_str());
+  #if defined(TARGET_VRX_BACKPACK)
   sendRTCChangesToVrx = true;
+  #endif
   AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", "RTC clock synced with NTP server.");
   response->addHeader("Connection", "close");
   request->send(response);

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -69,6 +69,7 @@ unsigned long rebootTime = 0;
 uint8_t cachedIndex = 0;
 bool sendChannelChangesToVrx = false;
 bool sendHeadTrackingChangesToVrx = false;
+bool sendRTCChangesToVrx = false;
 bool gotInitialPacket = false;
 bool headTrackingEnabled = false;
 uint32_t lastSentRequest = 0;
@@ -445,6 +446,11 @@ void loop()
 
   if (connectionState == wifiUpdate)
   {
+    if (sendRTCChangesToVrx)
+    {
+      sendRTCChangesToVrx = false;
+      vrxModule.SetRTC();
+    }
     return;
   }
 

--- a/src/hdzero.cpp
+++ b/src/hdzero.cpp
@@ -2,6 +2,7 @@
 #include "hdzero.h"
 #include "msptypes.h"
 #include "logging.h"
+#include "time.h"
 
 void
 HDZero::Init()
@@ -106,5 +107,28 @@ HDZero::SendHeadTrackingEnableCmd(bool enable)
     packet.function = MSP_ELRS_BACKPACK_SET_HEAD_TRACKING;
     packet.addByte(enable);
 
+    msp.sendPacket(&packet, m_port);
+}
+
+void
+HDZero::SetRTC()
+{
+    MSP msp;
+    mspPacket_t packet;
+    tm timeData;
+    if(!getLocalTime(&timeData)) {
+        DBGLN("Could not obtain time data.");
+        return;
+    }
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_SET_RTC;
+    packet.addByte(timeData.tm_year);
+    packet.addByte(timeData.tm_mon);
+    packet.addByte(timeData.tm_mday);
+    packet.addByte(timeData.tm_hour);
+    packet.addByte(timeData.tm_min);
+    packet.addByte(timeData.tm_sec);
+    
     msp.sendPacket(&packet, m_port);
 }

--- a/src/hdzero.h
+++ b/src/hdzero.h
@@ -24,4 +24,5 @@ public:
     uint8_t GetRecordingState();
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
     void SendHeadTrackingEnableCmd(bool enable);
+    void SetRTC();
 };

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -38,6 +38,11 @@ ModuleBase::SendHeadTrackingEnableCmd(bool enable)
 }
 
 void
+ModuleBase::SetRTC()
+{
+}
+
+void
 ModuleBase::Loop(uint32_t now)
 {
 }

--- a/src/module_base.h
+++ b/src/module_base.h
@@ -11,6 +11,7 @@ public:
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
     void SetOSD(mspPacket_t *packet);
     void SendHeadTrackingEnableCmd(bool enable);
+    void SetRTC();
     void Loop(uint32_t now);
 };
 

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -1,6 +1,6 @@
 # ------------------------- COMMON ENV DEFINITIONS -----------------
 [env]
-platform = espressif8266@3.2.0
+platform = espressif8266@4.2.0
 framework = arduino
 extra_scripts =
 	pre:python/build_flags.py


### PR DESCRIPTION
As the HDZero goggles got support for a RTC clock I decided to add the capability of updating said RTC clock via the ELRS backpack.

The backpack will make sure that it is in station mode (connected to another WiFi AP) so that it can fetch the time data from a NTP server on the local network or the internet. In that case it will display a new tab in the web panel that allows the user to specify a NTP server, their timezone offset in hours, from -12 to 12, and if they use DST or not. 

Also update the PlatformIO platform version to 4.2.0 to match the main ELRS repo as well as fix the issues regarding the time functions in the ESP8266/ESP8285 targets.