### PR TITLE
Remove `.` from target name

### DIFF
--- a/targets/hdzero.ini
+++ b/targets/hdzero.ini
@@ -2,7 +2,7 @@
 # VRX backpack targets
 # ********************************
 
-[env:HDZero_RX5.1_ESP8285_Backpack_via_UART]
+[env:HDZero_RX51_ESP8285_Backpack_via_UART]
 extends = env_common_esp8285, hdzero_vrx_backpack_common
 monitor_speed = 115200
 build_flags =
@@ -10,10 +10,10 @@ build_flags =
 	${hdzero_vrx_backpack_common.build_flags}
 	-D PIN_LED=16
 
-[env:HDZero_RX5.1_ESP8285_Backpack_via_WIFI]
-extends = env:HDZero_RX5.1_ESP8285_Backpack_via_UART
+[env:HDZero_RX51_ESP8285_Backpack_via_WIFI]
+extends = env:HDZero_RX51_ESP8285_Backpack_via_UART
 
-[env:HDZero_RX5.1_ESP32_Backpack_via_UART]
+[env:HDZero_RX51_ESP32_Backpack_via_UART]
 extends = env_common_esp32, hdzero_vrx_backpack_common
 monitor_speed = 115200
 build_flags =
@@ -22,10 +22,10 @@ build_flags =
 	-D PIN_LED=4
 lib_ignore = STM32UPDATE
 
-[env:HDZero_RX5.1_ESP32_Backpack_via_WIFI]
-extends = env:HDZero_RX5.1_ESP32_Backpack_via_UART
+[env:HDZero_RX51_ESP32_Backpack_via_WIFI]
+extends = env:HDZero_RX51_ESP32_Backpack_via_UART
 
-[env:HDZero_Goggle_RX5.1_ESP32_Backpack_via_UART]
+[env:HDZero_Goggle_ESP32_Backpack_via_UART]
 extends = env_common_esp32, hdzero_vrx_backpack_common
 monitor_speed = 115200
 build_flags =
@@ -35,5 +35,5 @@ build_flags =
 	-D NO_AUTOBIND=1
 lib_ignore = STM32UPDATE
 
-[env:HDZero_Goggle_RX5.1_ESP32_Backpack_via_WIFI]
-extends = env:HDZero_Goggle_RX5.1_ESP32_Backpack_via_UART
+[env:HDZero_Goggle_ESP32_Backpack_via_WIFI]
+extends = env:HDZero_Goggle_ESP32_Backpack_via_UART


### PR DESCRIPTION
Because, you know, PIO!
 PIO had an upgrade recently and now we can't have nice things anymore! Like dots in the target name!