### PR TITLE
Don't leak msppacket every Get on HDZero/Skyzone

### DIFF
--- a/src/hdzero.cpp
+++ b/src/hdzero.cpp
@@ -25,19 +25,19 @@ uint8_t
 HDZero::GetChannelIndex()
 {
     MSP msp;
-    mspPacket_t* packet = new mspPacket_t;
-    packet->reset();
-    packet->makeCommand();
-    packet->function = MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX;
 
     // Send request, then wait for a response back from the VRX
-    bool receivedResponse = msp.awaitPacket(packet, m_port, VRX_RESPONSE_TIMEOUT);
+    bool receivedResponse = msp.awaitPacket(&packet, m_port, VRX_RESPONSE_TIMEOUT);
 
     if (receivedResponse)
     {
-        packet = msp.getReceivedPacket();
+        mspPacket_t *packetResponse = msp.getReceivedPacket();
         msp.markPacketReceived();
-        return packet->readByte();
+        return packetResponse->readByte();
     }
 
     DBGLN("HDZero module: Exceeded timeout while waiting for channel index response");
@@ -61,19 +61,19 @@ uint8_t
 HDZero::GetRecordingState()
 {
     MSP msp;
-    mspPacket_t* packet = new mspPacket_t;
-    packet->reset();
-    packet->makeCommand();
-    packet->function = MSP_ELRS_BACKPACK_GET_RECORDING_STATE;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_GET_RECORDING_STATE;
 
     // Send request, then wait for a response back from the VRX
-    bool receivedResponse = msp.awaitPacket(packet, m_port, VRX_RESPONSE_TIMEOUT);
+    bool receivedResponse = msp.awaitPacket(&packet, m_port, VRX_RESPONSE_TIMEOUT);
 
     if (receivedResponse)
     {
-        packet = msp.getReceivedPacket();
+        mspPacket_t *packetResponse = msp.getReceivedPacket();
         msp.markPacketReceived();
-        return packet->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
+        return packetResponse->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
     }
 
     DBGLN("HDZero module: Exceeded timeout while waiting for recording state response");
@@ -136,6 +136,6 @@ HDZero::SetRTC()
     packet.addByte(timeData.tm_hour);
     packet.addByte(timeData.tm_min);
     packet.addByte(timeData.tm_sec);
-    
+
     msp.sendPacket(&packet, m_port);
 }

--- a/src/skyzone_msp.cpp
+++ b/src/skyzone_msp.cpp
@@ -24,19 +24,19 @@ uint8_t
 SkyzoneMSP::GetChannelIndex()
 {
     MSP msp;
-    mspPacket_t* packet = new mspPacket_t;
-    packet->reset();
-    packet->makeCommand();
-    packet->function = MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_GET_CHANNEL_INDEX;
 
     // Send request, then wait for a response back from the VRX
-    bool receivedResponse = msp.awaitPacket(packet, m_port, VRX_RESPONSE_TIMEOUT);
+    bool receivedResponse = msp.awaitPacket(&packet, m_port, VRX_RESPONSE_TIMEOUT);
 
     if (receivedResponse)
     {
-        packet = msp.getReceivedPacket();
+        mspPacket_t* packetResponse = msp.getReceivedPacket();
         msp.markPacketReceived();
-        return packet->readByte();
+        return packetResponse->readByte();
     }
 
     DBGLN("Skyzone module: Exceeded timeout while waiting for channel index response");
@@ -60,19 +60,19 @@ uint8_t
 SkyzoneMSP::GetRecordingState()
 {
     MSP msp;
-    mspPacket_t* packet = new mspPacket_t;
-    packet->reset();
-    packet->makeCommand();
-    packet->function = MSP_ELRS_BACKPACK_GET_RECORDING_STATE;
+    mspPacket_t packet;
+    packet.reset();
+    packet.makeCommand();
+    packet.function = MSP_ELRS_BACKPACK_GET_RECORDING_STATE;
 
     // Send request, then wait for a response back from the VRX
-    bool receivedResponse = msp.awaitPacket(packet, m_port, VRX_RESPONSE_TIMEOUT);
+    bool receivedResponse = msp.awaitPacket(&packet, m_port, VRX_RESPONSE_TIMEOUT);
 
     if (receivedResponse)
     {
-        packet = msp.getReceivedPacket();
+        mspPacket_t *packetResponse = msp.getReceivedPacket();
         msp.markPacketReceived();
-        return packet->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
+        return packetResponse->readByte() ? VRX_DVR_RECORDING_ACTIVE : VRX_DVR_RECORDING_INACTIVE;
     }
 
     DBGLN("Skyzone module: Exceeded timeout while waiting for recording state response");


### PR DESCRIPTION
`GetRecordingState()` and `GetChannelIndex()` on HDZero and Skyzone VRX Backpacks allocate a new msppacket every call, but never free it. This fixes it by using a value off the stack instead of the heap.

The msppacket structure is pretty big since it contains a 64 byte buffer in addition to its other members so this will add up, but it is unlikely anyone would run out of memory due to this even though every `SendIndexCmd()` calls Get at least twice.

