### PR TITLE
Fix flashed binding

### DIFF
--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -238,12 +238,13 @@ void SendCachedMSP()
 
 void SetSoftMACAddress()
 {
-  DBGLN("EEPROM MAC = ");
+  if (!firmwareOptions.hasUID)
+  {
+    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6);
+  }
+  DBG("EEPROM MAC = ");
   for (int i = 0; i < 6; i++)
   {
-    #ifndef MY_UID
-    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6);
-    #endif
     DBG("%x", firmwareOptions.uid[i]); // Debug prints
     DBG(",");
   }

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -278,12 +278,13 @@ void SetupEspNow()
 
 void SetSoftMACAddress()
 {
-  DBGLN("EEPROM MAC = ");
+  if (!firmwareOptions.hasUID)
+  {
+    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6);
+  }
+  DBG("EEPROM MAC = ");
   for (int i = 0; i < 6; i++)
   {
-    #ifndef MY_UID
-    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6);
-    #endif
     DBG("%x", firmwareOptions.uid[i]); // Debug prints
     DBG(",");
   }

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -352,12 +352,15 @@ void checkIfInBindingMode()
   {
     resetBootCounter();
 
-    #ifdef MY_UID
-    RebootIntoWifi();
-    #else
-    connectionState = binding;
-    bindingStart = millis();
-    #endif
+    if (firmwareOptions.hasUID)
+    {
+      RebootIntoWifi();
+    }
+    else
+    {
+      connectionState = binding;
+      bindingStart = millis();
+    }
   }
   else
   {


### PR DESCRIPTION
As part of the extraction to support binary flashing the UID handling was not correct.
The UID was being overwritten by the configuration value because when the firmware is build there is no UID so it assumes that the configuration should always be used.

This change checks if there is a flashed UID and will always use that if there is one.