### PR TITLE
Passthrough for Betaflight MSP SET_NAME commands

### DIFF
--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -2,6 +2,7 @@
 
 #define MSP_ELRS_FUNC                           0x4578 // ['E','x']
 
+#define MSP_SET_NAME                            11   //in message          Get board name - betaflight
 #define MSP_SET_RX_CONFIG                       45
 #define MSP_VTX_CONFIG                          88   //out message         Get vtx settings - betaflight
 #define MSP_SET_VTX_CONFIG                      89   //in message          Set vtx settings - betaflight

--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -2,7 +2,7 @@
 
 #define MSP_ELRS_FUNC                           0x4578 // ['E','x']
 
-#define MSP_SET_NAME                            11   //in message          Get board name - betaflight
+#define MSP_BF_SET_NAME                         11   //in message          Get board name - betaflight
 #define MSP_SET_RX_CONFIG                       45
 #define MSP_VTX_CONFIG                          88   //out message         Get vtx settings - betaflight
 #define MSP_SET_VTX_CONFIG                      89   //in message          Set vtx settings - betaflight
@@ -21,6 +21,7 @@
 #define MSP_ELRS_SET_RX_LOAN_MODE               0x0F
 #define MSP_ELRS_GET_BACKPACK_VERSION           0x10
 #define MSP_ELRS_BACKPACK_CRSF_TLM              0x11
+#define MSP_ELRS_SET_NAME                       0x12
 #define MSP_ELRS_SET_OSD                        0x00B6
 
 // CRSF encapsulated msp defines

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -75,21 +75,13 @@ void RebootIntoWifi()
 
 void ProcessMSPPacketFromPeer(mspPacket_t *packet)
 {
-  if (packet->function == MSP_SET_NAME) {
-    DBGLN("MSP_SET_NAME...");
-    msp.sendPacket(packet, &Serial);
-    return;
-  }
-
   switch (packet->function) {
-    /*
-    // THIS throws a "error: duplicate case value" error for some reason, therefore i used the if statement above
-    case MSP_SET_NAME: {
+    case MSP_ELRS_SET_NAME: {
       DBGLN("MSP_SET_NAME...");
+      packet->function = MSP_BF_SET_NAME;
       msp.sendPacket(packet, &Serial);
       break;
     }
-    */
     case MSP_ELRS_REQU_VTX_PKT: {
       DBGLN("MSP_ELRS_REQU_VTX_PKT...");
       // request from the vrx-backpack to send cached VTX packet

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -75,7 +75,21 @@ void RebootIntoWifi()
 
 void ProcessMSPPacketFromPeer(mspPacket_t *packet)
 {
+  if (packet->function == MSP_SET_NAME) {
+    DBGLN("MSP_SET_NAME...");
+    msp.sendPacket(packet, &Serial);
+    return;
+  }
+
   switch (packet->function) {
+    /*
+    // THIS throws a "error: duplicate case value" error for some reason, therefore i used the if statement above
+    case MSP_SET_NAME: {
+      DBGLN("MSP_SET_NAME...");
+      msp.sendPacket(packet, &Serial);
+      break;
+    }
+    */
     case MSP_ELRS_REQU_VTX_PKT: {
       DBGLN("MSP_ELRS_REQU_VTX_PKT...");
       // request from the vrx-backpack to send cached VTX packet


### PR DESCRIPTION
What does this add?
This PR enables the transmission of Betaflight SET_NAME MSP commands for setting the "Craft Name" field via ELRS.
see this PR for reference: [https://github.com/ExpressLRS/ExpressLRS/pull/2504](https://github.com/ExpressLRS/ExpressLRS/pull/2504)

Why should we add this?
In order to support (e.g.) racetimers sending lap time information and other messages to the OSD,
currently Betaflight does not (yet) support such information in a native way so we "abuse" the craft name field (like DJI V1 did ^^).
Once Betaflight supports this type of information we will refactor to use whatever new logic will be there...

Any reference to how this will/is beeing used?
I am working on an extension/PR to this RotorHazard plugin, which displays lap time information in FPV Goggles using a variety of techniques.
https://github.com/i-am-grub/VRxC_ELRS

This is my Fork, though its not yet 100% complete, therefore no PR exists yet.
https://github.com/UAV-Painkillers/VRxC_ELRS

This is the related ExpressLRS PR
[https://github.com/ExpressLRS/ExpressLRS/pull/2504](https://github.com/ExpressLRS/ExpressLRS/pull/2504)