### PR TITLE
Pin AsyncTCP to specific version

### DIFF
--- a/targets/common.ini
+++ b/targets/common.ini
@@ -8,6 +8,7 @@ extra_scripts =
 	pre:python/build_html.py
 lib_deps =
 	ottowinter/ESPAsyncWebServer-esphome @ 3.0.0
+	esphome/AsyncTCP-esphome @ 2.0.1 # use specific version - an update to this library breaks the build
 	bblanchon/ArduinoJson @ 6.19.4
 
 [common_env_data]


### PR DESCRIPTION
This fixes the build because an update to an unmanaged transitive dependency broke the build!