### PR TITLE
Mismatch in parameter count for esp8266 upload

### DIFF
--- a/python/build_env_setup.py
+++ b/python/build_env_setup.py
@@ -16,7 +16,6 @@ def copy_bootfile(source, target, env):
     shutil.copyfile(FRAMEWORK_DIR + "/tools/partitions/boot_app0.bin", env.subst("$BUILD_DIR") + "/boot_app0.bin")
 
 if platform in ['espressif8266']:
-    env.AddPostAction("buildprog", esp_compress.compressFirmware)
     env.AddPreAction("${BUILD_DIR}/spiffs.bin",
                      [esp_compress.compress_files])
     env.AddPreAction("${BUILD_DIR}/${ESP8266_FS_IMAGE_NAME}.bin",
@@ -45,3 +44,5 @@ try:
 except FileNotFoundError:
     None
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", UnifiedConfiguration.appendConfiguration)
+if platform in ['espressif8266'] and "_WIFI" in target_name:
+    env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp_compress.compressFirmware)

--- a/python/upload_via_esp8266_backpack.py
+++ b/python/upload_via_esp8266_backpack.py
@@ -1,6 +1,6 @@
 import subprocess, os
 
-def do_upload(elrs_bin_target, upload_addr, isstm, env):
+def do_upload(elrs_bin_target, pio_target, upload_addr, isstm, env):
     bootloader_target = None
     app_start = 0 # eka bootloader offset
 
@@ -65,7 +65,9 @@ def on_upload(source, target, env):
     bin_path = os.path.dirname(firmware_path)
     elrs_bin_target = os.path.join(bin_path, 'firmware.elrs')
     if not os.path.exists(elrs_bin_target):
-        elrs_bin_target = os.path.join(bin_path, 'firmware.bin')
+        elrs_bin_target = os.path.join(bin_path, 'firmware.bin.gz')
         if not os.path.exists(elrs_bin_target):
-            raise Exception("No valid binary found!")
+            elrs_bin_target = os.path.join(bin_path, 'firmware.bin')
+            if not os.path.exists(elrs_bin_target):
+                raise Exception("No valid binary found!")
     do_upload(elrs_bin_target, pio_target, upload_addr, isstm, env)


### PR DESCRIPTION
Build & Upload from VSCode throws this error on upload because... well because there's an error in the python? 😄 
```
Looking for upload port...
Using manually specified: elrs_vrx.local
*** [upload] TypeError : do_upload() takes 4 positional arguments but 5 were given
Traceback (most recent call last):
Uploading .pio\build\Skyzone_SteadyView_ESP_RX_Backpack_via_WIFI\firmware.bin
  File "C:\Users\bmayland\.platformio\packages\tool-scons\scons-local-4.5.2\SCons\Action.py", line 1310, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "C:\Users\bmayland\Documents\GitHub Projects\ExpressLRS-Backpack\python\upload_via_esp8266_backpack.py", line 71, in on_upload
    do_upload(elrs_bin_target, pio_target, upload_addr, isstm, env)
TypeError: do_upload() takes 4 positional arguments but 5 were given
```

I dunno how this is working for anyone else flashing their backpack, I guess maybe the Configurator uses a different python file?

### gzip firmware

Also, the firmware is too large to upload and needs to be gzipped, but the "buildprog" step does not appear to fire if uploading  (only if "Build" is chosen first). That's ok, because the upload script also only will upload a bin, not a bin.gz. This PR also changes the build to be like the ELRS main firmware, adding a postbuild to the .bin file **after** the config is appended (the current code would also GZIP it **before** the config was added).

