### PR TITLE
Update power levels for wifi modes to full power

### DIFF
--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -454,10 +454,10 @@ static void startWiFi(unsigned long now)
   WiFi.disconnect();
   WiFi.mode(WIFI_OFF);
   #if defined(PLATFORM_ESP8266)
-    WiFi.setOutputPower(13);
+    WiFi.setOutputPower(20.5);
     WiFi.setPhyMode(WIFI_PHY_MODE_11N);
   #elif defined(PLATFORM_ESP32)
-    WiFi.setTxPower(WIFI_POWER_13dBm);
+    WiFi.setTxPower(WIFI_POWER_19_5dBm);
   #endif
   if (firmwareOptions.home_wifi_ssid[0] != 0) {
     strcpy(station_ssid, firmwareOptions.home_wifi_ssid);

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -254,6 +254,11 @@ void SetSoftMACAddress()
   firmwareOptions.uid[0] = firmwareOptions.uid[0] & ~0x01;
 
   WiFi.mode(WIFI_STA);
+  #if defined(PLATFORM_ESP8266)
+    WiFi.setOutputPower(20.5);
+  #elif defined(PLATFORM_ESP32)
+    WiFi.setTxPower(WIFI_POWER_19_5dBm);
+  #endif
   WiFi.begin("network-name", "pass-to-network", 1);
   WiFi.disconnect();
 

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -294,6 +294,11 @@ void SetSoftMACAddress()
   firmwareOptions.uid[0] = firmwareOptions.uid[0] & ~0x01;
 
   WiFi.mode(WIFI_STA);
+  #if defined(PLATFORM_ESP8266)
+    WiFi.setOutputPower(20.5);
+  #elif defined(PLATFORM_ESP32)
+    WiFi.setTxPower(WIFI_POWER_19_5dBm);
+  #endif
   WiFi.begin("network-name", "pass-to-network", 1);
   WiFi.disconnect();
 


### PR DESCRIPTION
Increase the wifi module output power on ESP32 devices to 19.5dBm and ESP8266 to 20.5dBm.
These are the maximum values supported by these devices.