### PR TITLE
Add MAVLink support to Backpack

### DIFF
--- a/lib/BUTTON/devButton.cpp
+++ b/lib/BUTTON/devButton.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include "common.h"
 #include "device.h"
+#include "config.h"
 
 #if defined(PIN_BUTTON)
 #include "logging.h"
@@ -9,7 +10,7 @@
 static Button<PIN_BUTTON, false> button;
 
 extern unsigned long rebootTime;
-void RebootIntoWifi();
+void RebootIntoWifi(wifi_service_t service);
 
 static void shortPress()
 {
@@ -19,7 +20,7 @@ static void shortPress()
     }
     else
     {
-        RebootIntoWifi();
+        RebootIntoWifi(WIFI_SERVICE_UPDATE);
     }
 }
 

--- a/lib/MAVLink/MAVLink.cpp
+++ b/lib/MAVLink/MAVLink.cpp
@@ -1,0 +1,51 @@
+#if defined(MAVLINK_ENABLED)
+#include <Arduino.h>
+#include "MAVLink.h"
+#include <config.h>
+
+// Returns whether the message is a control message, i.e. a message where we don't want to
+// pass the message to the flight controller, but rather handle it ourselves. If the message
+// is a control message, the function handles it internally.
+bool MAVLink::handleControlMessage(mavlink_message_t *msg)
+{
+    bool shouldForward = true;
+    // Check for messages addressed to the Backpack
+    switch (msg->msgid)
+    {
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        mavlink_command_int_t commandMsg;
+        mavlink_msg_command_int_decode(msg, &commandMsg);
+        if (commandMsg.target_component == MAV_COMP_ID_UDP_BRIDGE)
+        {
+            shouldForward = false;
+            constexpr uint8_t ELRS_MODE_CHANGE = 0x8;
+            switch (commandMsg.command)
+            {
+            case MAV_CMD_USER_1:
+                switch ((int)commandMsg.param1)
+                {
+                case ELRS_MODE_CHANGE:
+                    switch ((int)commandMsg.param2)
+                    {
+                    case 0: // TX_NORMAL_MODE
+                        config.SetStartWiFiOnBoot(false);
+                        ESP.restart();
+                        break;
+                    case 1: // TX_MAVLINK_MODE
+                        if (config.GetWiFiService() != WIFI_SERVICE_MAVLINK_TX)
+                        {
+                            config.SetWiFiService(WIFI_SERVICE_MAVLINK_TX);
+                            config.SetStartWiFiOnBoot(true);
+                            config.Commit();
+                            ESP.restart();
+                        }
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+    }
+    return shouldForward;
+}
+#endif

--- a/lib/MAVLink/MAVLink.h
+++ b/lib/MAVLink/MAVLink.h
@@ -1,0 +1,9 @@
+#if defined(MAVLINK_ENABLED)
+#include "common/mavlink.h"
+
+class MAVLink
+{
+public:
+    static bool handleControlMessage(mavlink_message_t* msg);
+};
+#endif

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -831,6 +831,7 @@ static void HandleWebUpdate()
         logPos = 0;
       }
 #endif
+      }
     }
 
 #if defined(MAVLINK_ENABLED)

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -796,29 +796,29 @@ static void HandleWebUpdate()
               }
               break;
             }
-            if (shouldForward)
+          }
+          if (shouldForward)
+          {
+            // Track gaps in the sequence number, add to a dropped counter
+            uint8_t seq = msg.seq;
+            if (expectedSeqSet && seq != expectedSeq)
             {
-              // Track gaps in the sequence number, add to a dropped counter
-              uint8_t seq = msg.seq;
-              if (expectedSeqSet && seq != expectedSeq)
+              // account for rollovers
+              if (seq < expectedSeq)
               {
-                // account for rollovers
-                if (seq < expectedSeq)
-                {
-                  mavlink_stats.drops_downlink += (UINT8_MAX - expectedSeq) + seq;
-                }
-                else
-                {
-                  mavlink_stats.drops_downlink += seq - expectedSeq;
-                }
+                mavlink_stats.drops_downlink += (UINT8_MAX - expectedSeq) + seq;
               }
-              expectedSeq = seq + 1;
-              expectedSeqSet = true;
-              // Forward the message to the GCS
-              mavlink_to_gcs_buf[mavlink_to_gcs_buf_count] = msg;
-              mavlink_to_gcs_buf_count++;
-              mavlink_stats.packets_downlink++;
+              else
+              {
+                mavlink_stats.drops_downlink += seq - expectedSeq;
+              }
             }
+            expectedSeq = seq + 1;
+            expectedSeqSet = true;
+            // Forward the message to the GCS
+            mavlink_to_gcs_buf[mavlink_to_gcs_buf_count] = msg;
+            mavlink_to_gcs_buf_count++;
+            mavlink_stats.packets_downlink++;
           }
         }
 #else

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -692,9 +692,9 @@ static void HandleWebUpdate()
         } else if (wifiService == WIFI_SERVICE_MAVLINK_TX) {
           // Generate a unique SSID using config.address as hex
           sprintf(wifi_ap_ssid, "ExpressLRS TX %02X%02X%02X",
-            config.GetGroupAddress()[3],
-            config.GetGroupAddress()[4],
-            config.GetGroupAddress()[5]
+            firmwareOptions.uid[3],
+            firmwareOptions.uid[4],
+            firmwareOptions.uid[5]
           );
         }
 #endif

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -760,7 +760,7 @@ static void HandleWebUpdate()
         if (mavlink_to_gcs_buf_count >= MAVLINK_BUF_SIZE)
         {
           mavlink_stats.overflows_downlink++;
-          return;
+          mavlink_to_gcs_buf_count = 0;
         }
         if (mavlink_frame_char(MAVLINK_COMM_0, val, &mavlink_to_gcs_buf[mavlink_to_gcs_buf_count], &status) != MAVLINK_FRAMING_INCOMPLETE)
         {

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -687,7 +687,7 @@ static void HandleWebUpdate()
           strcpy(wifi_ap_ssid, "ExpressLRS TX Backpack");
         } else if (wifiService == WIFI_SERVICE_MAVLINK_TX) {
           // Generate a unique SSID using config.address as hex
-          sprintf(wifi_ap_ssid, "ExpressLRS TX %02X%02X%02X",
+          sprintf(wifi_ap_ssid, "ExpressLRS TX Backpack %02X%02X%02X",
             firmwareOptions.uid[3],
             firmwareOptions.uid[4],
             firmwareOptions.uid[5]

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -775,13 +775,13 @@ static void HandleWebUpdate()
             if (commandMsg.target_component == MAV_COMP_ID_UDP_BRIDGE)
             {
               shouldForward = false;
-              constexpr uint16_t MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE = 0x8;
+              constexpr uint8_t ELRS_MODE_CHANGE = 0x8;
               switch (commandMsg.command)
               {
               case MAV_CMD_USER_1:
                 switch ((int)commandMsg.param1)
                 {
-                case MAVLINK_TUNNEL_MSG_TYPE_ELRS_MODE_CHANGE:
+                case ELRS_MODE_CHANGE:
                   switch ((int)commandMsg.param2)
                   {
                   case 0: // TX_NORMAL_MODE

--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -821,6 +821,7 @@ static void HandleWebUpdate()
             mavlink_stats.packets_downlink++;
           }
         }
+      }
 #else
       int val = Serial.read();
       logBuffer[logPos++] = val;
@@ -831,7 +832,6 @@ static void HandleWebUpdate()
         logPos = 0;
       }
 #endif
-      }
     }
 
 #if defined(MAVLINK_ENABLED)

--- a/lib/config/config.cpp
+++ b/lib/config/config.cpp
@@ -51,6 +51,7 @@ TxBackpackConfig::SetDefaults()
     m_config.ssid[0] = 0;
     m_config.password[0] = 0;
     memset(m_config.address, 0, 6);
+    m_config.wifiService = WIFI_SERVICE_UPDATE;
     m_modified = true;
     Commit();
 }
@@ -83,6 +84,12 @@ TxBackpackConfig::SetGroupAddress(const uint8_t address[6])
     m_modified = true;
 }
 
+void
+TxBackpackConfig::SetWiFiService(wifi_service_t service)
+{
+    m_config.wifiService = service;
+    m_modified = true;
+}
 #endif
 
 /////////////////////////////////////////////////////

--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -11,13 +11,21 @@
 #define VRX_BACKPACK_CONFIG_VERSION     3
 #define TIMER_BACKPACK_CONFIG_VERSION   3
 
+
+typedef enum {
+    WIFI_SERVICE_UPDATE,
+    WIFI_SERVICE_MAVLINK_TX,
+} wifi_service_t;
+
 #if defined(TARGET_TX_BACKPACK)
+
 typedef struct {
-    uint32_t    version;
-    bool        startWiFi;
-    char        ssid[33];
-    char        password[65];
-    uint8_t     address[6];
+    uint32_t          version;
+    bool              startWiFi;
+    char              ssid[33];
+    char              password[65];
+    uint8_t           address[6];
+    wifi_service_t    wifiService;
 } tx_backpack_config_t;
 
 class TxBackpackConfig
@@ -32,6 +40,7 @@ public:
     char    *GetSSID() { return m_config.ssid; }
     char    *GetPassword() { return m_config.password; }
     uint8_t *GetGroupAddress() { return m_config.address; }
+    wifi_service_t GetWiFiService() { return m_config.wifiService; }
 
     // Setters
     void SetStorageProvider(ELRS_EEPROM *eeprom);
@@ -40,6 +49,7 @@ public:
     void SetSSID(const char *ssid);
     void SetPassword(const char *ssid);
     void SetGroupAddress(const uint8_t address[6]);
+    void SetWiFiService(wifi_service_t service);
 
 private:
     tx_backpack_config_t    m_config;

--- a/src/Timer_main.cpp
+++ b/src/Timer_main.cpp
@@ -87,7 +87,7 @@ void registerPeer(uint8_t* address);
 esp_now_peer_info_t peerInfo;
 #endif
 
-void RebootIntoWifi()
+void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE)
 {
   DBGLN("Rebooting into wifi update mode...");
   config.SetStartWiFiOnBoot(true);

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -23,8 +23,7 @@
 #include "devLED.h"
 
 #if defined(MAVLINK_ENABLED)
-#include "common/mavlink.h"
-
+#include <MAVLink.h>
 #endif
 
 /////////// GLOBALS ///////////
@@ -249,9 +248,12 @@ void SendCachedMSP()
 
 #if defined(MAVLINK_ENABLED)
 // This function is only used when we're not yet in WiFi MAVLink mode - its main purpose is to detect
-// heartbeat packets and switch to WiFi MAVLink mode if we receive 3 heartbeats in 5 seconds.
+// heartbeat packets and switch to WiFi MAVLink mode if we receive 3 heartbeats in 5 seconds, or if we
+// receive a command to switch to WiFi MAVLink mode.
 void ProcessMAVLinkFromTX(mavlink_message_t *mavlink_rx_message, mavlink_status_t *mavlink_status)
 {
+  // See if we have an explicit control message
+  MAVLink::handleControlMessage(mavlink_rx_message);
   static unsigned long heartbeatTimestamps[3] = {0, 0, 0};
   switch (mavlink_rx_message->msgid)
   {

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -84,6 +84,7 @@ void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE)
   rebootTime = millis();
 }
 
+#if defined(MAVLINK_ENABLED)
 void ProcessMSPPacketFromPeer(mspPacket_t *packet)
 {
   switch (packet->function) {
@@ -108,6 +109,7 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
     }
   }
 }
+#endif
 
 // espnow on-receive callback
 #if defined(PLATFORM_ESP8266)
@@ -429,6 +431,7 @@ void loop()
       ProcessMSPPacketFromTX(msp.getReceivedPacket());
       msp.markPacketReceived();
     }
+#if defined(MAVLINK_ENABLED)
     // Process MAVLink messages to switch to wifi update mode
     mavlink_message_t mavlink_rx_message;
     mavlink_status_t mavlink_status;
@@ -437,6 +440,7 @@ void loop()
       ProcessMAVLinkFromTX(&mavlink_rx_message, &mavlink_status);
     }
   }
+#endif
 
   if (cacheFull && sendCached)
   {

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -342,7 +342,7 @@ void setup()
     Serial1.setDebugOutput(true);
   #endif
   Serial.begin(460800);
-  Serial.setRxBufferSize(1024);
+  Serial.setRxBufferSize(4096);
 
   options_init();
 

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -84,7 +84,6 @@ void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE)
   rebootTime = millis();
 }
 
-#if defined(MAVLINK_ENABLED)
 void ProcessMSPPacketFromPeer(mspPacket_t *packet)
 {
   switch (packet->function) {
@@ -109,7 +108,6 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
     }
   }
 }
-#endif
 
 // espnow on-receive callback
 #if defined(PLATFORM_ESP8266)
@@ -249,6 +247,7 @@ void SendCachedMSP()
   }
 }
 
+#if defined(MAVLINK_ENABLED)
 // This function is only used when we're not yet in WiFi MAVLink mode - its main purpose is to detect
 // heartbeat packets and switch to WiFi MAVLink mode if we receive 3 heartbeats in 5 seconds.
 void ProcessMAVLinkFromTX(mavlink_message_t *mavlink_rx_message, mavlink_status_t *mavlink_status)
@@ -283,6 +282,7 @@ void ProcessMAVLinkFromTX(mavlink_message_t *mavlink_rx_message, mavlink_status_
   }
   }
 }
+#endif
 
 void SetSoftMACAddress()
 {

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -439,8 +439,8 @@ void loop()
     {
       ProcessMAVLinkFromTX(&mavlink_rx_message, &mavlink_status);
     }
-  }
 #endif
+  }
 
   if (cacheFull && sendCached)
   {

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -342,6 +342,7 @@ void setup()
     Serial1.setDebugOutput(true);
   #endif
   Serial.begin(460800);
+  Serial.setRxBufferSize(1024);
 
   options_init();
 

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -22,6 +22,11 @@
 #include "devButton.h"
 #include "devLED.h"
 
+#if defined(MAVLINK_ENABLED)
+#include "common/mavlink.h"
+
+#endif
+
 /////////// GLOBALS ///////////
 
 uint8_t bindingAddress[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
@@ -29,6 +34,8 @@ uint8_t bindingAddress[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 const uint8_t version[] = {LATEST_VERSION};
 
 connectionState_e connectionState = starting;
+// Assume we are in wifi update mode until we know otherwise
+wifi_service_t wifiService = WIFI_SERVICE_UPDATE;
 unsigned long rebootTime = 0;
 
 bool cacheFull = false;
@@ -65,10 +72,14 @@ void sendMSPViaEspnow(mspPacket_t *packet);
 esp_now_peer_info_t peerInfo;
 #endif
 
-void RebootIntoWifi()
+void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE)
 {
   DBGLN("Rebooting into wifi update mode...");
   config.SetStartWiFiOnBoot(true);
+#if defined(TARGET_TX_BACKPACK)
+  // TODO it might be better to add wifi service to each type of backpack
+  config.SetWiFiService(service);
+#endif
   config.Commit();
   rebootTime = millis();
 }
@@ -236,6 +247,25 @@ void SendCachedMSP()
   }
 }
 
+void ProcessMAVLinkFromTX(mavlink_message_t *mavlink_rx_message, mavlink_status_t *mavlink_status)
+{
+    switch (mavlink_rx_message->msgid)
+    {
+      case MAVLINK_MSG_ID_HEARTBEAT:
+      {
+        mavlink_heartbeat_t heartbeat;
+        mavlink_msg_heartbeat_decode(mavlink_rx_message, &heartbeat);
+        if (mavlink_rx_message->compid == MAV_COMP_ID_AUTOPILOT1)
+        {
+          if (connectionState != wifiUpdate) {
+            RebootIntoWifi(WIFI_SERVICE_MAVLINK_TX);
+          }
+        }
+        break;
+      }
+    }
+}
+
 void SetSoftMACAddress()
 {
   if (!firmwareOptions.hasUID)
@@ -310,6 +340,12 @@ void setup()
   if (config.GetStartWiFiOnBoot())
   {
     config.SetStartWiFiOnBoot(false);
+    if (config.GetWiFiService() != WIFI_SERVICE_UPDATE)
+    {
+      // Store the intended service mode before writing default back to persistent flash
+      wifiService = config.GetWiFiService();
+      config.SetWiFiService(WIFI_SERVICE_UPDATE);
+    }
     config.Commit();
     connectionState = wifiUpdate;
     devicesTriggerEvent();
@@ -376,6 +412,13 @@ void loop()
       // Finished processing a complete packet
       ProcessMSPPacketFromTX(msp.getReceivedPacket());
       msp.markPacketReceived();
+    }
+    // Process MAVLink messages to switch to wifi update mode
+    mavlink_message_t mavlink_rx_message;
+    mavlink_status_t mavlink_status;
+    if (mavlink_parse_char(MAVLINK_COMM_0, c, &mavlink_rx_message, &mavlink_status))
+    {
+      ProcessMAVLinkFromTX(&mavlink_rx_message, &mavlink_status);
     }
   }
 

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -127,7 +127,7 @@ void SetupEspNow();
 
 /////////////////////////////////////
 
-void RebootIntoWifi()
+void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE)
 {
   DBGLN("Rebooting into wifi update mode...");
   config.SetStartWiFiOnBoot(true);

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -5,8 +5,9 @@
 #include "device.h"
 #include "msptypes.h"
 #include "logging.h"
+#include <config.h>
 
-void RebootIntoWifi();
+void RebootIntoWifi(wifi_service_t service = WIFI_SERVICE_UPDATE);
 bool BindingExpired(uint32_t now);
 extern uint8_t backpackVersion[];
 extern bool headTrackingEnabled;

--- a/targets/common.ini
+++ b/targets/common.ini
@@ -14,6 +14,8 @@ lib_deps =
 [common_env_data]
 build_src_filter = +<*> -<.git/> -<svn/> -<example/> -<examples/> -<test/> -<tests/> -<*.py> -<*test*.*>
 build_flags = -Wall -Iinclude
+# keep in sync with the version in the main firmware
+mavlink_lib_dep = https://github.com/mavlink/c_library_v2.git#e54a8d2e8cf7985e689ad1c8c8f37dc0800ea87b
 
 # ------------------------- COMMON ESP8285 DEFINITIONS -----------------
 [env_common_esp8285]
@@ -65,6 +67,8 @@ lib_ignore = STM32UPDATE
 build_flags =
 	${common_env_data.build_flags}
 	-D TARGET_TX_BACKPACK
+lib_deps =
+	${env.lib_deps}
 build_src_filter = ${common_env_data.build_src_filter} -<Vrx_main.cpp> -<rapidfire.*> -<rx5808.*> -<steadyview.*> -<fusion.*> -<hdzero.*> -<skyzone_msp.*> -<orqa.*> -<Timer_main.cpp>
 
 # ------------------------- COMMON RAPIDFIRE-BACKPACK DEFINITIONS -----------------

--- a/targets/txbp_esp.ini
+++ b/targets/txbp_esp.ini
@@ -4,9 +4,13 @@
 
 [env:ESP_TX_Backpack_via_UART]
 extends = env_common_esp8285, tx_backpack_common
+lib_deps =
+	${tx_backpack_common.lib_deps}
+	${common_env_data.mavlink_lib_dep}
 build_flags =
 	${env_common_esp8285.build_flags}
 	${tx_backpack_common.build_flags}
+	-D MAVLINK_ENABLED=1
 	-D PIN_BUTTON=0
 	-D PIN_LED=16
 upload_resetmethod = nodemcu

--- a/targets/txbp_esp.ini
+++ b/targets/txbp_esp.ini
@@ -31,9 +31,13 @@ upload_command = python "$PROJECT_DIR/python/external/esptool/esptool.py" --pass
 
 [env:ESP32C3_TX_Backpack_via_UART]
 extends = env_common_esp32c3, tx_backpack_common
+lib_deps =
+	${tx_backpack_common.lib_deps}
+	${common_env_data.mavlink_lib_dep}
 build_flags =
 	${env_common_esp32c3.build_flags}
 	${tx_backpack_common.build_flags}
+	-D MAVLINK_ENABLED=1
 	-D PIN_BUTTON=9
 	-D PIN_LED=8
 upload_resetmethod = nodemcu


### PR DESCRIPTION
Should be easy as pie to use - Backpack autodetects when it sees MAVLink heartbeats and starts a WiFi network, and runs the "standard" UDP ports so Mission Planner should auto connect. Additionally, with https://github.com/ExpressLRS/ExpressLRS/pull/2867, the TX now requests backpack mode changes as soon as link mode is set. 

Open questions:

* WiFi PSKs?
* ~~Does it work on STA mode? No reason why not, but haven't tested~~ Yes.
* ~~More counters / status?~~
* ~~How do we get Backpack out of MAVLink mode? Could simultaneously parse MSP and look for an exit command, or just say "nah reboot"~~ https://github.com/ExpressLRS/ExpressLRS/pull/2867