### PR TITLE
Add missing targets

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -149,6 +149,29 @@
             }
         }
     },
+    "jumper": {
+        "name": "Jumper",
+        "txbp": {
+            "t12-max": {
+                "product_name": "Jumper T-12 Max Internal TX Modules",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["uart", "wifi"]
+            },
+            "t15": {
+                "product_name": "Jumper T-15 Internal TX Modules",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["uart", "wifi"]
+            },
+            "t20": {
+                "product_name": "Jumper T-20 Internal TX Modules with Backpack extension",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["uart", "wifi"]
+            }
+        }
+    },
     "namimnorc": {
         "name": "NamimnoRC",
         "txbp": {

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -2,14 +2,20 @@
     "generic": {
         "name": "Generic backpack for any TX module",
         "txbp": {
-            "esp": {
-                "product_name": "Backpack for ESP32-based TX module",
+            "esp8285": {
+                "product_name": "ESP8285 Backpack for ESP32-based TX module",
                 "firmware": "ESP_TX_Backpack",
                 "upload_methods": ["uart", "etx", "passthru", "wifi"],
                 "platform": "esp8285"
             },
+            "esp32-c3": {
+                "product_name": "ESP32-C3 Backpack for ESP32-based TX module",
+                "firmware": "ESP32C3_TX_Backpack",
+                "upload_methods": ["uart", "etx", "passthru", "wifi"],
+                "platform": "esp32-c3"
+            },
             "stm": {
-                "product_name": "Backpack for STM32-based TX module",
+                "product_name": "ESP8285 Backpack for STM32-based TX module",
                 "firmware": "STM_TX_Backpack",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp8285"
@@ -439,7 +445,7 @@
             }
         }
     },
-    "timer": {
+    "generic-timer": {
         "name": "Generic backpack for any Race Timer",
         "timer": {
             "esp32": {
@@ -475,7 +481,7 @@
         }
     },
     "rotorhazard": {
-        "name": "RotorHazard",
+        "name": "RotorHazard Timer Backpack",
         "timer": {
             "esp32": {
                 "product_name": "ESP32 Module (DIY)",
@@ -506,6 +512,17 @@
                 "firmware": "TIMER_ESP32S3_Backpack",
                 "upload_methods": ["uart", "wifi"],
                 "platform": "esp32-s3"
+            }
+        }
+    },
+    "diy-aat": {
+        "name": "DIY Automatic Antenna Tracker Backpack",
+        "aat": {
+            "pwmrx": {
+                "product_name": "5xPWM Receiver",
+                "firmware": "AAT_ESP_Backpack",
+                "upload_methods": ["uart", "wifi"],
+                "platform": "esp8285"
             }
         }
     }


### PR DESCRIPTION
Adds missing targets to the `targets.json` file used by configurator and the web-flasher.

- ESP32-C3 backpack for TX modules
- Jumper T12 Max, T15 and T20 backpacks
- DIY antenna tracker