### PR TITLE
Fix the firmware file for the HDZero goggles

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -340,8 +340,8 @@
         "vrx": {
             "esp32": {
                 "product_name": "Built-in ESP32 Backpack",
-                "firmware": "HDZero_RX51_ESP32_Backpack",
-                "upload_methods": ["wifi"],
+                "firmware": "HDZero_Goggle_ESP32_Backpack",
+                "upload_methods": ["wifi", "zip"],
                 "platform": "esp32"
             }
         }


### PR DESCRIPTION
Also, adds a 'zip' download method for the flasher. This method will zip all the files for putting on the SDCard in the goggles.