### PR TITLE
Remove "zip" type from targets file

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -341,7 +341,7 @@
             "esp32": {
                 "product_name": "Built-in ESP32 Backpack",
                 "firmware": "HDZero_Goggle_ESP32_Backpack",
-                "upload_methods": ["wifi", "zip"],
+                "upload_methods": ["wifi"],
                 "platform": "esp32"
             }
         }


### PR DESCRIPTION
Revert adding the "zip" upload type from the targets file until it no longer causes conniptions for configurator.