### PR TITLE
Fox ETX pass through on jumper internal modules

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -156,19 +156,19 @@
                 "product_name": "Jumper T-12 Max Internal TX Modules",
                 "firmware": "ESP_TX_Backpack",
                 "platform": "esp8285",
-                "upload_methods": ["uart", "wifi"]
+                "upload_methods": ["etx", "wifi"]
             },
             "t15": {
                 "product_name": "Jumper T-15 Internal TX Modules",
                 "firmware": "ESP_TX_Backpack",
                 "platform": "esp8285",
-                "upload_methods": ["uart", "wifi"]
+                "upload_methods": ["etx", "wifi"]
             },
             "t20": {
                 "product_name": "Jumper T-20 Internal TX Modules with Backpack extension",
                 "firmware": "ESP_TX_Backpack",
                 "platform": "esp8285",
-                "upload_methods": ["uart", "wifi"]
+                "upload_methods": ["uart", "etx" ,"wifi"]
             }
         }
     },


### PR DESCRIPTION
Bit of an oversight not adding ETX passthrough flashing for the latest Jumper internal modules!