### PR TITLE
Update GX12 backpack name

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -300,7 +300,7 @@
                 "upload_methods": ["passthru", "wifi"]
             },
             "gx12": {
-                "product_name": "GX12 Dual-Band Gemini-X TX",
+                "product_name": "RadioMaster GX12 Dual-Band Gemini-X TX",
                 "firmware": "ESP32C3_TX_Backpack",
                 "platform": "esp32-c3",
                 "upload_methods": ["etx", "wifi"]


### PR DESCRIPTION
Add "RadioMaster " to GX12 backpack name to make consistent with other RadioMaster backpack targets.