### PR TITLE
Fixes USBSerial connected VRx devices

### DIFF
--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -552,7 +552,7 @@ void loop()
   }
 
 #if defined(PLATFORM_ESP32)
-  if (uxQueueMessagesWaiting(rxqueue) > 0 && Serial.availableForWrite() == 128)
+  if (uxQueueMessagesWaiting(rxqueue) > 0 && Serial.availableForWrite() >= 128)
     {
       mspPacket_t rxPacket;
       if (xQueueReceive(rxqueue, &rxPacket, (TickType_t)512) == pdTRUE)


### PR DESCRIPTION
# Problem
None of the MSP packets are being process on the S3 Debug VRx!

# Solution
The issue is that the default 'Serial' device is the HWCDC device which has a ring buffer size of 256, NOT the 128 that is being currently checked!