### PR TITLE
MSP Race Condition

### DIFF
--- a/src/Timer_main.cpp
+++ b/src/Timer_main.cpp
@@ -147,10 +147,11 @@ void OnDataRecv(uint8_t * mac_addr, uint8_t *data, uint8_t data_len)
 void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
 #endif
 {
+  MSP recv_msp;
   DBGLN("ESP NOW DATA:");
   for(int i = 0; i < data_len; i++)
   {
-    if (msp.processReceivedByte(data[i]))
+    if (recv_msp.processReceivedByte(data[i]))
     {
       // Finished processing a complete packet
       // Only process packets from a bound MAC address
@@ -166,12 +167,12 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
           )
       {
         #if defined(PLATFORM_ESP8266)
-          ProcessMSPPacketFromTimer(msp.getReceivedPacket(), millis());
+          ProcessMSPPacketFromTimer(recv_msp.getReceivedPacket(), millis());
         #elif defined(PLATFORM_ESP32)
-          xQueueSend(rxqueue, msp.getReceivedPacket(), (TickType_t)1024);
+          xQueueSend(rxqueue, recv_msp.getReceivedPacket(), (TickType_t)1024);
         #endif
       }
-      msp.markPacketReceived();
+      recv_msp.markPacketReceived();
     }
   }
   blinkLED();

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -118,10 +118,11 @@ void OnDataRecv(uint8_t * mac_addr, uint8_t *data, uint8_t data_len)
 void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
 #endif
 {
+  MSP recv_msp;
   DBGLN("ESP NOW DATA:");
   for(int i = 0; i < data_len; i++)
   {
-    if (msp.processReceivedByte(data[i]))
+    if (recv_msp.processReceivedByte(data[i]))
     {
       // Finished processing a complete packet
       // Only process packets from a bound MAC address
@@ -132,9 +133,9 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
           firmwareOptions.uid[4] == mac_addr[4] &&
           firmwareOptions.uid[5] == mac_addr[5])
       {
-        ProcessMSPPacketFromPeer(msp.getReceivedPacket());
+        ProcessMSPPacketFromPeer(recv_msp.getReceivedPacket());
       }
-      msp.markPacketReceived();
+      recv_msp.markPacketReceived();
     }
   }
   blinkLED();

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -151,12 +151,13 @@ void OnDataRecv(uint8_t * mac_addr, uint8_t *data, uint8_t data_len)
 void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
 #endif
 {
+  MSP recv_msp;
   DBGVLN("ESP NOW DATA:");
   for(int i = 0; i < data_len; i++)
   {
     DBGV("%x,", data[i]); // Debug prints
 
-    if (msp.processReceivedByte(data[i]))
+    if (recv_msp.processReceivedByte(data[i]))
     {
       DBGVLN(""); // Extra line for serial output readability
       // Finished processing a complete packet
@@ -174,16 +175,16 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
       {
         gotInitialPacket = true;
         #if defined(PLATFORM_ESP8266)
-          ProcessMSPPacket(msp.getReceivedPacket());
+          ProcessMSPPacket(recv_msp.getReceivedPacket());
         #elif defined(PLATFORM_ESP32)
-          xQueueSend(rxqueue, msp.getReceivedPacket(), (TickType_t)1024);
+          xQueueSend(rxqueue, recv_msp.getReceivedPacket(), (TickType_t)1024);
         #endif
       }
       else
       {
         DBGLN("Failed MAC add check and not in bindingMode.");
       }
-      msp.markPacketReceived();
+      recv_msp.markPacketReceived();
     }
   }
   blinkLED();


### PR DESCRIPTION
Addressing a potential race condition caused through the use of the global MSP instance.

ESPNOW callbacks on the ESP32 are spawned in a FreeRTOS task outside of the main system loop; this task can run concurrently to the main loop. Using a single instance of the MSP class between these two tasks can create a situation where data received at the same time from both the serial and ESPNOW interfaces are unintentionally combined during the parsing sequence.

This occurrence is more likely to happen in situations involving OSD packets due to the extra data load. The effects of this race condition occurring are unknown, but it may be related to reported instances of the backpack OSD in the HDZero goggles suddenly stopping.