### PR TITLE
 Device Type Addressing

### DIFF
--- a/lib/config/config.h
+++ b/lib/config/config.h
@@ -2,10 +2,15 @@
 
 #include "elrs_eeprom.h"
 
+// Identifier for type of backpack
+#define TX_BACKPACK_TYPE_ID     (0b01U)
+#define VRX_BACKPACK_TYPE_ID    (0b10U)
+#define TIMER_BACKPACK_TYPE_ID  (0b11U)
+
 // CONFIG_MAGIC is ORed with CONFIG_VERSION in the version field
-#define TX_BACKPACK_CONFIG_MAGIC    (0b01U << 30)
-#define VRX_BACKPACK_CONFIG_MAGIC   (0b10U << 30)
-#define TIMER_BACKPACK_CONFIG_MAGIC (0b11U << 30)
+#define TX_BACKPACK_CONFIG_MAGIC    (TX_BACKPACK_TYPE_ID << 30)
+#define VRX_BACKPACK_CONFIG_MAGIC   (VRX_BACKPACK_TYPE_ID << 30)
+#define TIMER_BACKPACK_CONFIG_MAGIC (TIMER_BACKPACK_TYPE_ID << 30)
 
 #define TX_BACKPACK_CONFIG_VERSION      4
 #define VRX_BACKPACK_CONFIG_VERSION     5

--- a/src/Timer_main.cpp
+++ b/src/Timer_main.cpp
@@ -160,8 +160,7 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
             firmwareOptions.uid[1] == mac_addr[1] &&
             firmwareOptions.uid[2] == mac_addr[2] &&
             firmwareOptions.uid[3] == mac_addr[3] &&
-            firmwareOptions.uid[4] == mac_addr[4] &&
-            firmwareOptions.uid[5] == mac_addr[5]
+            firmwareOptions.uid[4] == mac_addr[4]
             )
           )
       {
@@ -340,6 +339,8 @@ void SetSoftMACAddress()
 
   // MAC address can only be set with unicast, so first byte must be even, not odd
   firmwareOptions.uid[0] = firmwareOptions.uid[0] & ~0x01;
+  // Set MAC address to be specific for type of device
+  firmwareOptions.uid[5] = TIMER_BACKPACK_TYPE_ID;
 
   WiFi.mode(WIFI_STA);
   #if defined(PLATFORM_ESP8266)
@@ -447,8 +448,6 @@ void setup()
       esp_now_register_send_cb(OnDataSent);
       xSemaphoreGive(semaphore);
     #endif
-
-    registerPeer(firmwareOptions.uid);
 
     memcpy(sendAddress, firmwareOptions.uid, 6);
   }

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -125,12 +125,14 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
     {
       // Finished processing a complete packet
       // Only process packets from a bound MAC address
-      if (firmwareOptions.uid[0] == mac_addr[0] &&
+      if ((firmwareOptions.uid[0] == mac_addr[0] &&
           firmwareOptions.uid[1] == mac_addr[1] &&
           firmwareOptions.uid[2] == mac_addr[2] &&
           firmwareOptions.uid[3] == mac_addr[3] &&
-          firmwareOptions.uid[4] == mac_addr[4] &&
-          firmwareOptions.uid[5] == mac_addr[5])
+          firmwareOptions.uid[4] == mac_addr[4]
+        ) ||
+        TIMER_BACKPACK_TYPE_ID == mac_addr[5]
+      )
       {
         ProcessMSPPacketFromPeer(msp.getReceivedPacket());
       }
@@ -269,7 +271,8 @@ void sendMSPViaEspnow(mspPacket_t *packet)
   }
   else
   {
-    esp_now_send(firmwareOptions.uid, (uint8_t *) &nowDataOutput, packetSize);
+    // Address set to NULL sends data to all registered peers
+    esp_now_send(NULL, (uint8_t *) &nowDataOutput, packetSize);
   }
 
   blinkLED();
@@ -309,6 +312,8 @@ void SetSoftMACAddress()
 
   // MAC address can only be set with unicast, so first byte must be even, not odd
   firmwareOptions.uid[0] = firmwareOptions.uid[0] & ~0x01;
+  // Set MAC address to be specific for type of device
+  firmwareOptions.uid[5] = TX_BACKPACK_TYPE_ID;
 
   WiFi.mode(WIFI_STA);
   #if defined(PLATFORM_ESP8266)
@@ -388,11 +393,16 @@ void setup()
       rebootTime = millis();
     }
 
+    // Create the peer address for transmitter with same UID
+    uint8_t peer_address[6];
+    memcpy(peer_address, firmwareOptions.uid, 6);
+    peer_address[5] = VRX_BACKPACK_TYPE_ID;
+
     #if defined(PLATFORM_ESP8266)
       esp_now_set_self_role(ESP_NOW_ROLE_COMBO);
-      esp_now_add_peer(firmwareOptions.uid, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
+      esp_now_add_peer(peer_address, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
     #elif defined(PLATFORM_ESP32)
-      memcpy(peerInfo.peer_addr, firmwareOptions.uid, 6);
+      memcpy(peerInfo.peer_addr, peer_address, 6);
       peerInfo.channel = 0;
       peerInfo.encrypt = false;
       if (esp_now_add_peer(&peerInfo) != ESP_OK)

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -160,16 +160,17 @@ void OnDataRecv(const uint8_t * mac_addr, const uint8_t *data, int data_len)
     {
       DBGVLN(""); // Extra line for serial output readability
       // Finished processing a complete packet
-      // Only process packets from a bound MAC address
+      // Only process packets from a bound MAC address or a timer backpack
+      // if not in bind mode
       if (connectionState == binding ||
             (
             firmwareOptions.uid[0] == mac_addr[0] &&
             firmwareOptions.uid[1] == mac_addr[1] &&
             firmwareOptions.uid[2] == mac_addr[2] &&
             firmwareOptions.uid[3] == mac_addr[3] &&
-            firmwareOptions.uid[4] == mac_addr[4] &&
-            firmwareOptions.uid[5] == mac_addr[5]
-            )
+            firmwareOptions.uid[4] == mac_addr[4] 
+            ) ||
+            TIMER_BACKPACK_TYPE_ID == mac_addr[5]
           )
       {
         gotInitialPacket = true;
@@ -286,11 +287,16 @@ void SetupEspNow()
       ESP.restart();
     }
 
+    // Create the peer address for transmitter with same UID
+    uint8_t peer_address[6];
+    memcpy(peer_address, firmwareOptions.uid, 6);
+    peer_address[5] = TX_BACKPACK_TYPE_ID;
+
     #if defined(PLATFORM_ESP8266)
       esp_now_set_self_role(ESP_NOW_ROLE_COMBO);
-      esp_now_add_peer(firmwareOptions.uid, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
+      esp_now_add_peer(peer_address, ESP_NOW_ROLE_COMBO, 1, NULL, 0);
     #elif defined(PLATFORM_ESP32)
-      memcpy(peerInfo.peer_addr, firmwareOptions.uid, 6);
+      memcpy(peerInfo.peer_addr, peer_address, 6);
       peerInfo.channel = 0;
       peerInfo.encrypt = false;
       if (esp_now_add_peer(&peerInfo) != ESP_OK)
@@ -307,7 +313,7 @@ void SetSoftMACAddress()
 {
   if (!firmwareOptions.hasUID)
   {
-    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6);
+    memcpy(firmwareOptions.uid, config.GetGroupAddress(), 6); 
   }
   DBG("EEPROM MAC = ");
   for (int i = 0; i < 6; i++)
@@ -319,6 +325,8 @@ void SetSoftMACAddress()
 
   // MAC address can only be set with unicast, so first byte must be even, not odd
   firmwareOptions.uid[0] = firmwareOptions.uid[0] & ~0x01;
+  // Set MAC address to be specific for type of device
+  firmwareOptions.uid[5] = VRX_BACKPACK_TYPE_ID;
 
   WiFi.mode(WIFI_STA);
   #if defined(PLATFORM_ESP8266)
@@ -369,7 +377,8 @@ void sendMSPViaEspnow(mspPacket_t *packet)
     return;
   }
 
-  esp_now_send(firmwareOptions.uid, (uint8_t *) &nowDataOutput, packetSize);
+  // Address set to NULL sends data to all registered peers
+  esp_now_send(NULL, (uint8_t *) &nowDataOutput, packetSize);
 }
 
 void resetBootCounter()


### PR DESCRIPTION
>  !!! Important !!! - Merging this PR will likely require a major version bump as it will break compatibility with previous versions of the backpack

This PR introduces individual addresses for each of the configurations of the backpack firmware (currently Tx, Vrx, timer) by replacing the last octet of the UID with the value of the config type. It is setup under the following assumptions: 

- The Tx and Vrx only have the intention of sending data to their counterpart 
- The Tx and Vrx can still receive data from any device with the first five octets of the UID matching. 
- The Tx and Vrx will accept data from any Timer backpack even without the first five octets matching.
- The Timer backpack can register/unregister Tx and Vrx peers from the command of it's host [unchanged]
- Accept data from any host when binding [unchanged]

This change allows for additional stability of the backpack in enabling accurate reporting of data delivery by the espnow send callback. For example, when trying to send OSD data to the Vrx backpack, a powered-on Tx backpack with the same address may report a successful data delivery when the Vrx failed to receive the expected data. This scenario breaks the timer backpack packet retransmit system allowing creating a measured 5-10% packet loss on the bench (currently with only the Vrx backpack on, there is a measured 0% loss).

This change also allows for the timer backpack to send to multiple peers without requiring it to configure its mac address before transmitting to a new peer. This enables the timer backpack's firmware to be changed to allow sending to multiple peers in parallel and not sequentially (which can have a noticeable delay for pilots who are last in the sequence)