### PR TITLE
Add target for RadioMaster TX15 internal backpack

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -286,6 +286,12 @@
                 "firmware": "ESP32C3_TX_Backpack",
                 "platform": "esp32-c3",
                 "upload_methods": ["etx", "wifi"]
+            },
+            "tx15": {
+                "product_name": "RadioMaster TX15 Dual-Band TX",
+                "firmware": "ESP32C3_TX_Backpack",
+                "platform": "esp32-c3",
+                "upload_methods": ["etx", "wifi"]
             }
         }
     },


### PR DESCRIPTION
Add target for TX15 internal backpack, tested and working for me, flashed the internal backpack via EdgeTX passthrough with a set bind phrase, enabling the backpack to link to mu AAT. 