### PR TITLE
Make CRSF telemetry accessible over WIFI as UDP broadcast

### DIFF
--- a/lib/WIFI/devWIFI.cpp
+++ b/lib/WIFI/devWIFI.cpp
@@ -122,36 +122,46 @@ bool gcsIPSet = false;
 #if defined(TARGET_TX_BACKPACK)
 bool SendTxBackpackTelemetryViaUDP(const uint8_t *data, uint16_t size)
 {
-  if (!data || size == 0) {
+  if (!data || size == 0)
+  {
     return false;
   }
 
 #if !defined(MAVLINK_ENABLED)
   return false;
 #else
-  if (!servicesStarted || !wifiStarted) {
+  if (!servicesStarted || !wifiStarted)
+  {
     return false;
   }
-  if (wifiService != WIFI_SERVICE_MAVLINK_TX) {
+  if (wifiService != WIFI_SERVICE_MAVLINK_TX)
+  {
     return false;
   }
 
   IPAddress remote;
   WiFiMode_t mode = WiFi.getMode();
-  if (mode == WIFI_AP || mode == WIFI_AP_STA) {
+  if (mode == WIFI_AP || mode == WIFI_AP_STA)
+  {
     remote = apBroadcast;
-  } else if (mode == WIFI_STA) {
+  }
+  else if (mode == WIFI_STA)
+  {
     remote = WiFi.broadcastIP();
-  } else {
+  }
+  else
+  {
     return false;
   }
 
-  if (!mavlinkUDP.beginPacket(remote, config.GetMavlinkSendPort())) {
+  if (!mavlinkUDP.beginPacket(remote, config.GetMavlinkSendPort()))
+  {
     return false;
   }
 
   size_t sent = mavlinkUDP.write(data, size);
-  if (sent != size) {
+  if (sent != size)
+  {
     mavlinkUDP.endPacket();
     return false;
   }

--- a/lib/WIFI/devWIFI.h
+++ b/lib/WIFI/devWIFI.h
@@ -7,4 +7,8 @@ extern device_t WIFI_device;
 #define HAS_WIFI
 
 extern const char *VERSION;
+
+#if defined(TARGET_TX_BACKPACK)
+bool SendTxBackpackTelemetryViaUDP(const uint8_t *data, uint16_t size);
+#endif
 #endif

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -228,6 +228,7 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     if (config.GetTelemMode() == BACKPACK_TELEM_MODE_WIFI)
     {
       sendMSPViaWiFiUDP(packet);
+      sendMSPViaEspnow(packet);
     }
     else if (config.GetTelemMode() != BACKPACK_TELEM_MODE_OFF)
     {

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -64,7 +64,7 @@ MAVLink mavlink;
 /////////// FUNCTION DEFS ///////////
 
 void sendMSPViaEspnow(mspPacket_t *packet);
-bool sendMSPViaWiFiUDP(mspPacket_t *packet);
+void sendMSPViaWiFiUDP(mspPacket_t *packet);
 
 /////////////////////////////////////
 
@@ -294,7 +294,7 @@ void sendMSPViaEspnow(mspPacket_t *packet)
   blinkLED();
 }
 
-bool sendMSPViaWiFiUDP(mspPacket_t *packet)
+void sendMSPViaWiFiUDP(mspPacket_t *packet)
 {
   uint8_t packetSize = msp.getTotalPacketSize(packet);
   uint8_t dataOutput[packetSize];
@@ -302,10 +302,10 @@ bool sendMSPViaWiFiUDP(mspPacket_t *packet)
   uint8_t result = msp.convertToByteArray(packet, dataOutput);
   if (!result)
   {
-    return false;
+    return;
   }
 
-  return SendTxBackpackTelemetryViaUDP(dataOutput, result);
+  SendTxBackpackTelemetryViaUDP(dataOutput, packetSize);
 }
 
 void SendCachedMSP()

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -228,9 +228,8 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     if (config.GetTelemMode() == BACKPACK_TELEM_MODE_WIFI)
     {
       sendMSPViaWiFiUDP(packet);
-      sendMSPViaEspnow(packet);
     }
-    else if (config.GetTelemMode() != BACKPACK_TELEM_MODE_OFF)
+    if (config.GetTelemMode() != BACKPACK_TELEM_MODE_OFF)
     {
       sendMSPViaEspnow(packet);
     }


### PR DESCRIPTION
This PR adds access to CRSF telemetry over Wi-Fi, which currently only works for MAVLink while CRSF telemetry is only available over ESP-NOW.

This is a minimal implementation that broadcasts CRSF telemetry packets via UDP. It reuses the existing Wi-Fi/MAVLink networking path and uses `mavlinkUDP.write()` on `MavlinkSendPort`.

UDP broadcast is active when telemetry mode is set to `WIFI` in the ELRS Lua script.

This should not interfere with MAVLink in normal use, since CRSF and MAVLink telemetry are not used at the same time as far as I know. I could not test how it behaves with real ESP-NOW receivers since I don't have the hardware.

Previously, ESP-NOW was active whenever telemetry mode was not `OFF` (so even when set to `WIFI`). I kept this behavior in place and added UDP broadcast. The behavior is now:
- `WIFI`: CRSF telemetry is sent via ESP-NOW and UDP broadcast.
- `ESP-NOW`: CRSF telemetry is sent via ESP-NOW only.
- `OFF`: no telemetry forwarding.

In my tests, this works in both AP and STA mode. I can receive the packets over UDP and parse/display telemetry fields successfully.

<img width="722" height="516" alt="image" src="https://github.com/user-attachments/assets/07b2d3f5-c8ee-4915-9564-fd7f99d0c912" />
