### PR TITLE
Fix wifi flashing via flasher.pyz

### DIFF
--- a/python/binary_configurator.py
+++ b/python/binary_configurator.py
@@ -58,10 +58,11 @@ def upload_wifi(args, mcuType, upload_addr):
             with open(args.file.name, 'rb') as f_in:
                 with gzip.open('firmware.bin.gz', 'wb') as f_out:
                     shutil.copyfileobj(f_in, f_out)
-            upload_via_esp8266_backpack.do_upload('firmware.bin.gz', upload_addr, False, {})
+            upload_via_esp8266_backpack.do_upload('firmware.bin.gz', upload_addr, {})
         else:
-            upload_via_esp8266_backpack.do_upload(args.file.name, upload_addr, False, {})
-    except:
+            upload_via_esp8266_backpack.do_upload(args.file.name, upload_addr, {})
+    except Exception as e:
+        print("WIFI upload failed: %s" % e, file=sys.stderr)
         return ElrsUploadResult.ErrorGeneral
     return ElrsUploadResult.Success
 

--- a/python/upload_via_esp8266_backpack.py
+++ b/python/upload_via_esp8266_backpack.py
@@ -18,7 +18,7 @@ def do_upload(elrs_bin_target, upload_addr, env):
         upload_addr = [upload_port]
 
     for addr in upload_addr:
-        addr = "http://%s/%s" % (addr, ['update', 'upload'])
+        addr = "http://%s/update" % (addr,)
         print(" ** UPLOADING TO: %s" % addr)
         try:
             if  bootloader_target is not None:


### PR DESCRIPTION
Restore call/signature alignment between binary_configurator and upload_via_esp8266_backpack, broken by the STM32 removal in 20d083c4 (#177):

- binary_configurator.upload_wifi: drop the orphaned `False` (was isstm) so the 3-param do_upload signature matches.
- upload_via_esp8266_backpack.do_upload: the `[isstm]` indexer was removed but the `['update', 'upload']` list literal was left in the URL format string, producing `http://elrs_txbp/['update', 'upload']`. Replace with `/update`.

Also tighten the bare `except:` in upload_wifi so failures surface as stderr instead of being silently masked.