### PR TITLE
Missing targets

### DIFF
--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -27,6 +27,29 @@
             }
         }
     },
+    "bayckrc": {
+        "name": "BAYCKRC",
+        "txbp": {
+            "nano-db": {
+                "product_name": "BAYCKRC 900/2400 Dual Band 1W Nano TX",
+                "firmware": "ESP32C3_TX_Backpack",
+                "platform": "esp32-c3",
+                "upload_methods": ["passthru", "wifi"]
+            },
+            "nano-dbx": {
+                "product_name": "BAYCKRC 900/2400 Dual Band 1W Nano Gemini TX",
+                "firmware": "ESP32C3_TX_Backpack",
+                "platform": "esp32-c3",
+                "upload_methods": ["passthru", "wifi"]
+            },
+            "micro-dbx": {
+                "product_name": "BAYCKRC 900/2400 Dual Band 1W Micro Gemini TX",
+                "firmware": "ESP32C3_TX_Backpack",
+                "platform": "esp32-c3",
+                "upload_methods": ["passthru", "wifi"]
+            }
+        }
+    },
     "betafpv": {
         "name": "BETAFPV",
         "txbp": {

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -188,6 +188,23 @@
             }
         }
     },
+    "hglrc": {
+        "name": "HGLRC",
+        "txbp": {
+            "oled-900": {
+                "product_name": "HGLRC OLED 900MHz TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["passthru", "wifi"]
+            },
+            "hermes-2g4": {
+                "product_name": "HGLRC Hermes 2.4GHz TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["passthru", "wifi"]
+            }
+        }
+    },
     "iflight": {
         "name": "iFlight",
         "txbp": {

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -152,6 +152,12 @@
         "name": "GEPRC",
         "txbp": {
             "linkflow900": {
+                "product_name": "GEPRC LINKFLOW 900M TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["passthru", "wifi"]
+            },
+            "linkflow900v2": {
                 "product_name": "GEPRC LINKFLOW 900M TX V2",
                 "firmware": "ESP32C3_TX_Backpack",
                 "platform": "esp32-c3",

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -208,12 +208,6 @@
                 "firmware": "ESP_TX_Backpack",
                 "platform": "esp8285",
                 "upload_methods": ["passthru", "wifi"]
-            },
-            "hermes-2g4": {
-                "product_name": "HGLRC Hermes 2.4GHz TX",
-                "firmware": "ESP_TX_Backpack",
-                "platform": "esp8285",
-                "upload_methods": ["passthru", "wifi"]
             }
         }
     },

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -237,6 +237,24 @@
     "jumper": {
         "name": "Jumper",
         "txbp": {
+            "bumblebee": {
+                "product_name": "Jumper AION Bumblebee 2.4GHz TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["etx", "wifi"]
+            },
+            "t-14": {
+                "product_name": "Jumper AION T-14 2.4GHz TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["etx", "wifi"]
+            },
+            "t-14-900": {
+                "product_name": "Jumper AION T-14 900M TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["etx", "wifi"]
+            },
             "t12-max": {
                 "product_name": "Jumper T-12 Max Internal TX Modules",
                 "firmware": "ESP_TX_Backpack",
@@ -254,6 +272,18 @@
                 "firmware": "ESP_TX_Backpack",
                 "platform": "esp8285",
                 "upload_methods": ["uart", "etx" ,"wifi"]
+            },
+            "t20v2": {
+                "product_name": "Jumper AION T-20 2.4GHz V2 TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["etx" ,"wifi"]
+            },
+            "t20-900v2": {
+                "product_name": "Jumper AION T-20 900M V2 TX",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["etx" ,"wifi"]
             }
         }
     },

--- a/hardware/targets.json
+++ b/hardware/targets.json
@@ -83,6 +83,12 @@
                 "platform": "esp8285",
                 "upload_methods": ["passthru", "wifi"]
             },
+            "micro900v2": {
+                "product_name": "BETAFPV 900MHz Micro TX V2",
+                "firmware": "ESP_TX_Backpack",
+                "platform": "esp8285",
+                "upload_methods": ["passthru", "wifi"]
+            },
             "superg": {
                 "product_name": "BETAFPV SuperG 2.4GHz Gemini TX",
                 "firmware": "ESP_TX_Backpack",


### PR DESCRIPTION
Adds a bunch of targets to the configurator apps as they have been missed or had non-specific generic targets.