### PR TITLE
Send RTC time and DVR recording name from the TX backpack to the goggles

### DIFF
--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -50,6 +50,7 @@
 #define MSP_ELRS_BACKPACK_SET_OSD_ELEMENT       0x030C
 #define MSP_ELRS_BACKPACK_SET_HEAD_TRACKING     0x030D  // enable/disable head-tracking forwarding packets to the TX
 #define MSP_ELRS_BACKPACK_SET_RTC               0x030E
+#define MSP_ELRS_BACKPACK_SET_DVR_NAME          0x030F
 
 // incoming, packets originating from the VRx
 #define MSP_ELRS_BACKPACK_SET_MODE              0x0380  // enable wifi/binding mode

--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -17,6 +17,9 @@
 #include "options.h"
 #include "helpers.h"
 
+#include "time.h"
+#include <sys/time.h>
+
 #include "device.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -39,6 +42,7 @@ unsigned long rebootTime = 0;
 
 bool cacheFull = false;
 bool sendCached = false;
+bool sendRTC = false;
 
 device_t *ui_devices[] = {
 #ifdef PIN_LED
@@ -98,6 +102,8 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
       {
         sendCached = true;
       }
+      // the vrx-backpack just booted, so send it the time as well
+      sendRTC = true;
       break;
     }
     case MSP_ELRS_BACKPACK_SET_PTR: {
@@ -240,6 +246,25 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     HandleConfigMsg(packet);
     break;
 
+  case MSP_ELRS_BACKPACK_SET_RTC:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_RTC...");
+    // Seed our local clock from the payload, then forward the
+    // time on to the VRX backpack
+    if (packet->payloadSize >= 6)
+    {
+      tm timeData = {};
+      timeData.tm_year = packet->payload[0];
+      timeData.tm_mon = packet->payload[1];
+      timeData.tm_mday = packet->payload[2];
+      timeData.tm_hour = packet->payload[3];
+      timeData.tm_min = packet->payload[4];
+      timeData.tm_sec = packet->payload[5];
+      timeval tv = {mktime(&timeData), 0};
+      settimeofday(&tv, NULL);
+      sendMSPViaEspnow(packet);
+    }
+    break;
+
   case MSP_ELRS_BIND:
     DBG("MSP_ELRS_BIND = ");
     for (int i = 0; i < 6; i++)
@@ -305,6 +330,31 @@ void sendMSPViaWiFiUDP(mspPacket_t *packet)
   }
 
   SendTxBackpackTelemetryViaUDP(dataOutput, packetSize);
+}
+
+void SendRTCViaEspnow()
+{
+  time_t now = time(NULL);
+  if (now < 1704067200) // 1 Jan 2024 - the local clock has not been set
+  {
+    return;
+  }
+
+  tm timeData;
+  localtime_r(&now, &timeData);
+
+  mspPacket_t packet;
+  packet.reset();
+  packet.makeCommand();
+  packet.function = MSP_ELRS_BACKPACK_SET_RTC;
+  packet.addByte(timeData.tm_year);
+  packet.addByte(timeData.tm_mon);
+  packet.addByte(timeData.tm_mday);
+  packet.addByte(timeData.tm_hour);
+  packet.addByte(timeData.tm_min);
+  packet.addByte(timeData.tm_sec);
+
+  sendMSPViaEspnow(&packet);
 }
 
 void SendCachedMSP()
@@ -487,5 +537,12 @@ void loop()
   {
     SendCachedMSP();
     sendCached = false;
+  }
+
+  // Send the time to the VRX backpack when it requests it at boot
+  if (connectionState == running && sendRTC)
+  {
+    sendRTC = false;
+    SendRTCViaEspnow();
   }
 }

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -19,6 +19,9 @@
 #include "config.h"
 #include "crsf_protocol.h"
 
+#include "time.h"
+#include <sys/time.h>
+
 #include "device.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -244,6 +247,24 @@ void ProcessMSPPacket(mspPacket_t *packet)
   case MSP_ELRS_SET_OSD:
     DBGLN("Processing MSP_ELRS_SET_OSD...");
     vrxModule.SetOSD(packet);
+    break;
+  case MSP_ELRS_BACKPACK_SET_RTC:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_RTC...");
+    if (packet->payloadSize >= 6)
+    {
+      // Set our local clock from the payload, then flag the time
+      // to be sent on to the goggles from the main loop
+      tm timeData = {};
+      timeData.tm_year = packet->readByte();
+      timeData.tm_mon = packet->readByte();
+      timeData.tm_mday = packet->readByte();
+      timeData.tm_hour = packet->readByte();
+      timeData.tm_min = packet->readByte();
+      timeData.tm_sec = packet->readByte();
+      timeval tv = {mktime(&timeData), 0};
+      settimeofday(&tv, NULL);
+      sendRTCChangesToVrx = true;
+    }
     break;
   case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
     DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
@@ -524,6 +545,11 @@ void loop()
     sendHeadTrackingChangesToVrx = false;
     vrxModule.SendHeadTrackingEnableCmd(headTrackingEnabled);
   }
+  if (sendRTCChangesToVrx)
+  {
+    sendRTCChangesToVrx = false;
+    vrxModule.SetRTC();
+  }
 
 #if !defined(NO_AUTOBIND)
   // Power cycle must be done within 30s.  Long timeout to allow goggles to boot and shutdown correctly e.g. Orqa.
@@ -536,11 +562,6 @@ void loop()
 
   if (connectionState == wifiUpdate)
   {
-    if (sendRTCChangesToVrx)
-    {
-      sendRTCChangesToVrx = false;
-      vrxModule.SetRTC();
-    }
     return;
   }
 

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -266,6 +266,12 @@ void ProcessMSPPacket(mspPacket_t *packet)
       sendRTCChangesToVrx = true;
     }
     break;
+  case MSP_ELRS_BACKPACK_SET_DVR_NAME:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_DVR_NAME...");
+    // Race label for the goggles to name the next DVR recording with;
+    // forwarded verbatim over the goggle serial link
+    vrxModule.ForwardPacket(packet);
+    break;
   case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
     DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
     headTrackingEnabled = packet->readByte();

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -40,6 +40,11 @@ ModuleBase::SetOSD(mspPacket_t *packet)
 }
 
 void
+ModuleBase::ForwardPacket(mspPacket_t *packet)
+{
+}
+
+void
 ModuleBase::SendHeadTrackingEnableCmd(bool enable)
 {
 }
@@ -164,6 +169,13 @@ MSPModuleBase::Loop(uint32_t now)
     }
 }
 
+
+// Pass a packet through to the connected device (e.g. the goggles) verbatim
+void
+MSPModuleBase::ForwardPacket(mspPacket_t *packet)
+{
+    msp.sendPacket(packet, m_port);
+}
 
 void
 MSPModuleBase::sendResponse(uint16_t function, const uint8_t *response, uint32_t responseSize)

--- a/src/module_base.h
+++ b/src/module_base.h
@@ -11,6 +11,7 @@ public:
     void SendIndexCmd(uint8_t index);
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
     void SetOSD(mspPacket_t *packet);
+    void ForwardPacket(mspPacket_t *packet);
     void SendHeadTrackingEnableCmd(bool enable);
     void SetRTC();
     void SendLinkTelemetry(uint8_t *rawCrsfPacket);
@@ -24,6 +25,7 @@ class MSPModuleBase : public ModuleBase
 public:
     MSPModuleBase(Stream *port) : m_port(port) {};
     void Loop(uint32_t);
+    void ForwardPacket(mspPacket_t *packet);
 
     void sendResponse(uint16_t function, const uint8_t *response, uint32_t responseSize);
 


### PR DESCRIPTION
## Summary

Two additions to the backpack ESP-NOW/MSP protocol, aimed at HDZero goggles but implemented via the standard module-dispatch pattern so other VRX modules can adopt them later:

### RTC time sync (`MSP_ELRS_BACKPACK_SET_RTC`, 0x030E — existing opcode, new transport)
- The TX backpack seeds its local clock when it receives `SET_RTC` on its serial port (in addition to the existing WiFi NTP path).
- When the VRX backpack requests its startup packet (`MSP_ELRS_REQU_VTX_PKT`), the TX backpack replies with the current time over ESP-NOW — only when its clock has actually been set, and only on request (no periodic resync).
- The VRX backpack sets its own system clock from the packet and forwards the time to the goggles over serial, reusing the existing `SetRTC()` path that previously only ran during WiFi NTP sync. On modules without an RTC serial protocol this is a no-op via the `ModuleBase` stub.

This gives HDZero goggles a correct clock (DVR file timestamps) without the pilot ever opening the backpack WiFi page.

### DVR recording name (`MSP_ELRS_BACKPACK_SET_DVR_NAME`, 0x030F — new opcode)
- Carries a race label the goggles use to name the next DVR recording.
- The VRX backpack forwards it verbatim over the goggle serial link via a new `MSPModuleBase::ForwardPacket`; a no-op on non-MSP backpack modules.

## Notes
- No changes to existing message handling; both features are additive and ignored by devices that don't implement them.
- `ModuleBase::SetRTC`/`ForwardPacket` follow the same empty-stub dispatch pattern as `SetOSD`/`SetRecordingState`.