### PR TITLE
Send RTC time from the TX backpack to the VRX backpack over ESP-NOW

### DIFF
--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -17,6 +17,9 @@
 #include "options.h"
 #include "helpers.h"
 
+#include "time.h"
+#include <sys/time.h>
+
 #include "device.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -39,6 +42,7 @@ unsigned long rebootTime = 0;
 
 bool cacheFull = false;
 bool sendCached = false;
+bool sendRTC = false;
 
 device_t *ui_devices[] = {
 #ifdef PIN_LED
@@ -98,6 +102,8 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
       {
         sendCached = true;
       }
+      // the vrx-backpack just booted, so send it the time as well
+      sendRTC = true;
       break;
     }
     case MSP_ELRS_BACKPACK_SET_PTR: {
@@ -240,6 +246,25 @@ void ProcessMSPPacketFromTX(mspPacket_t *packet)
     HandleConfigMsg(packet);
     break;
 
+  case MSP_ELRS_BACKPACK_SET_RTC:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_RTC...");
+    // Seed our local clock from the payload, then forward the
+    // time on to the VRX backpack
+    if (packet->payloadSize >= 6)
+    {
+      tm timeData = {};
+      timeData.tm_year = packet->payload[0];
+      timeData.tm_mon = packet->payload[1];
+      timeData.tm_mday = packet->payload[2];
+      timeData.tm_hour = packet->payload[3];
+      timeData.tm_min = packet->payload[4];
+      timeData.tm_sec = packet->payload[5];
+      timeval tv = {mktime(&timeData), 0};
+      settimeofday(&tv, NULL);
+      sendMSPViaEspnow(packet);
+    }
+    break;
+
   case MSP_ELRS_BIND:
     DBG("MSP_ELRS_BIND = ");
     for (int i = 0; i < 6; i++)
@@ -305,6 +330,31 @@ void sendMSPViaWiFiUDP(mspPacket_t *packet)
   }
 
   SendTxBackpackTelemetryViaUDP(dataOutput, packetSize);
+}
+
+void SendRTCViaEspnow()
+{
+  time_t now = time(NULL);
+  if (now < 1704067200) // 1 Jan 2024 - the local clock has not been set
+  {
+    return;
+  }
+
+  tm timeData;
+  localtime_r(&now, &timeData);
+
+  mspPacket_t packet;
+  packet.reset();
+  packet.makeCommand();
+  packet.function = MSP_ELRS_BACKPACK_SET_RTC;
+  packet.addByte(timeData.tm_year);
+  packet.addByte(timeData.tm_mon);
+  packet.addByte(timeData.tm_mday);
+  packet.addByte(timeData.tm_hour);
+  packet.addByte(timeData.tm_min);
+  packet.addByte(timeData.tm_sec);
+
+  sendMSPViaEspnow(&packet);
 }
 
 void SendCachedMSP()
@@ -487,5 +537,12 @@ void loop()
   {
     SendCachedMSP();
     sendCached = false;
+  }
+
+  // Send the time to the VRX backpack when it requests it at boot
+  if (connectionState == running && sendRTC)
+  {
+    sendRTC = false;
+    SendRTCViaEspnow();
   }
 }

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -19,6 +19,9 @@
 #include "config.h"
 #include "crsf_protocol.h"
 
+#include "time.h"
+#include <sys/time.h>
+
 #include "device.h"
 #include "devWIFI.h"
 #include "devButton.h"
@@ -244,6 +247,24 @@ void ProcessMSPPacket(mspPacket_t *packet)
   case MSP_ELRS_SET_OSD:
     DBGLN("Processing MSP_ELRS_SET_OSD...");
     vrxModule.SetOSD(packet);
+    break;
+  case MSP_ELRS_BACKPACK_SET_RTC:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_RTC...");
+    if (packet->payloadSize >= 6)
+    {
+      // Set our local clock from the payload, then flag the time
+      // to be sent on to the goggles from the main loop
+      tm timeData = {};
+      timeData.tm_year = packet->readByte();
+      timeData.tm_mon = packet->readByte();
+      timeData.tm_mday = packet->readByte();
+      timeData.tm_hour = packet->readByte();
+      timeData.tm_min = packet->readByte();
+      timeData.tm_sec = packet->readByte();
+      timeval tv = {mktime(&timeData), 0};
+      settimeofday(&tv, NULL);
+      sendRTCChangesToVrx = true;
+    }
     break;
   case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
     DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
@@ -524,6 +545,11 @@ void loop()
     sendHeadTrackingChangesToVrx = false;
     vrxModule.SendHeadTrackingEnableCmd(headTrackingEnabled);
   }
+  if (sendRTCChangesToVrx)
+  {
+    sendRTCChangesToVrx = false;
+    vrxModule.SetRTC();
+  }
 
 #if !defined(NO_AUTOBIND)
   // Power cycle must be done within 30s.  Long timeout to allow goggles to boot and shutdown correctly e.g. Orqa.
@@ -536,11 +562,6 @@ void loop()
 
   if (connectionState == wifiUpdate)
   {
-    if (sendRTCChangesToVrx)
-    {
-      sendRTCChangesToVrx = false;
-      vrxModule.SetRTC();
-    }
     return;
   }
 


### PR DESCRIPTION
## Summary

Syncs the VRX backpack's clock (and, on HDZero, the goggles' RTC) from the TX backpack, so DVR recordings get correct timestamps without the pilot ever opening the backpack WiFi page.

- The TX backpack seeds its local clock when it receives `MSP_ELRS_BACKPACK_SET_RTC` on its serial port (in addition to the existing WiFi NTP path).
- When the VRX backpack requests its startup packet (`MSP_ELRS_REQU_VTX_PKT`), the TX backpack replies with the current time over ESP-NOW — only when its clock has actually been set, and only on request (no periodic resync).
- The VRX backpack sets its own system clock from the packet and forwards the time to the goggles over serial, reusing the existing `SetRTC()` path that previously only ran during WiFi NTP sync. On modules without an RTC serial protocol this is a no-op via the existing `ModuleBase::SetRTC` stub.

Uses the existing `MSP_ELRS_BACKPACK_SET_RTC` (0x030E) opcode — this only adds a new transport for it. Additive only; devices that don't handle it ignore the message.

## Related PRs

- ExpressLRS/Lua-Scripts#18 — adds a **Sync Backpack Time** button to the ELRS Lua script that sends the handset's date/time to the TX module (field id `0x3C`), seeding the TX backpack clock that this PR distributes.
- ExpressLRS/Backpack#232 — forwards the DVR recording name to the goggles; recordings named by that feature get correct timestamps from this PR's time sync. Both PRs were split out of ExpressLRS/Backpack#230.
- hd-zero/hdzero-goggle#613 — goggle PR that names DVR recordings after the race; this PR's time sync gives those recordings correct timestamps.
- ExpressLRS/ExpressLRS#3701 — TX-module firmware PR that sends `MSP_ELRS_BACKPACK_SET_RTC` to the TX backpack, seeding the clock this PR distributes.
- hd-zero/hdzero-goggle#615 — makes the goggles' set-clock page show the live RTC, so pilots can see the synced time and can't accidentally save stale roller values over it.
