### PR TITLE
Forward MSP_ELRS_BACKPACK_SET_DVR_NAME to the goggles

### DIFF
--- a/lib/MSP/msptypes.h
+++ b/lib/MSP/msptypes.h
@@ -50,6 +50,7 @@
 #define MSP_ELRS_BACKPACK_SET_OSD_ELEMENT       0x030C
 #define MSP_ELRS_BACKPACK_SET_HEAD_TRACKING     0x030D  // enable/disable head-tracking forwarding packets to the TX
 #define MSP_ELRS_BACKPACK_SET_RTC               0x030E
+#define MSP_ELRS_BACKPACK_SET_DVR_NAME          0x030F
 
 // incoming, packets originating from the VRx
 #define MSP_ELRS_BACKPACK_SET_MODE              0x0380  // enable wifi/binding mode

--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -245,6 +245,12 @@ void ProcessMSPPacket(mspPacket_t *packet)
     DBGLN("Processing MSP_ELRS_SET_OSD...");
     vrxModule.SetOSD(packet);
     break;
+  case MSP_ELRS_BACKPACK_SET_DVR_NAME:
+    DBGLN("Processing MSP_ELRS_BACKPACK_SET_DVR_NAME...");
+    // Race label for the goggles to name the next DVR recording with;
+    // forwarded verbatim over the goggle serial link
+    vrxModule.ForwardPacket(packet);
+    break;
   case MSP_ELRS_BACKPACK_SET_HEAD_TRACKING:
     DBGLN("Processing MSP_ELRS_BACKPACK_SET_HEAD_TRACKING...");
     headTrackingEnabled = packet->readByte();

--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -40,6 +40,11 @@ ModuleBase::SetOSD(mspPacket_t *packet)
 }
 
 void
+ModuleBase::ForwardPacket(mspPacket_t *packet)
+{
+}
+
+void
 ModuleBase::SendHeadTrackingEnableCmd(bool enable)
 {
 }
@@ -164,6 +169,13 @@ MSPModuleBase::Loop(uint32_t now)
     }
 }
 
+
+// Pass a packet through to the connected device (e.g. the goggles) verbatim
+void
+MSPModuleBase::ForwardPacket(mspPacket_t *packet)
+{
+    msp.sendPacket(packet, m_port);
+}
 
 void
 MSPModuleBase::sendResponse(uint16_t function, const uint8_t *response, uint32_t responseSize)

--- a/src/module_base.h
+++ b/src/module_base.h
@@ -11,6 +11,7 @@ public:
     void SendIndexCmd(uint8_t index);
     void SetRecordingState(uint8_t recordingState, uint16_t delay);
     void SetOSD(mspPacket_t *packet);
+    void ForwardPacket(mspPacket_t *packet);
     void SendHeadTrackingEnableCmd(bool enable);
     void SetRTC();
     void SendLinkTelemetry(uint8_t *rawCrsfPacket);
@@ -24,6 +25,7 @@ class MSPModuleBase : public ModuleBase
 public:
     MSPModuleBase(Stream *port) : m_port(port) {};
     void Loop(uint32_t);
+    void ForwardPacket(mspPacket_t *packet);
 
     void sendResponse(uint16_t function, const uint8_t *response, uint32_t responseSize);
 


### PR DESCRIPTION
## Summary

Adds a new `MSP_ELRS_BACKPACK_SET_DVR_NAME` (0x030F) message carrying a race label the goggles use to name the next DVR recording (companion to the hdzero-goggle dvr-race-names feature).

- The VRX backpack forwards the packet verbatim over the goggle serial link via a new `MSPModuleBase::ForwardPacket`.
- `ModuleBase::ForwardPacket` is an empty stub, so non-MSP backpack modules (rapidfire, rx5808, etc.) ignore the message — same dispatch pattern as `SetOSD`/`SetRecordingState`.

Additive only: 21 lines, no changes to existing message handling.

## Related PRs

- ExpressLRS/Backpack#231 — sends RTC time from the TX backpack to the VRX backpack over ESP-NOW, so DVR recordings named by this feature also get correct timestamps. Both PRs were split out of ExpressLRS/Backpack#230.
- ExpressLRS/Lua-Scripts#18 — adds a **Sync Backpack Time** button to the ELRS Lua script that seeds the TX backpack clock from the handset.
- hd-zero/hdzero-goggle#613 — companion goggle PR: handles `MSP_SET_DVR_NAME` and names the next DVR recording with the received label.
- hd-zero/hdzero-goggle#614 — same race-timer integration: lets the timer also switch the goggles between Raceband and Lowband (independent of this PR).
