### PR TITLE
Fix ESP32-S3 ESP-NOW startup timing

### DIFF
--- a/src/Vrx_main.cpp
+++ b/src/Vrx_main.cpp
@@ -329,6 +329,10 @@ void SetSoftMACAddress()
     esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_11B | WIFI_PROTOCOL_11G | WIFI_PROTOCOL_11N | WIFI_PROTOCOL_LR);
   #endif
   WiFi.begin("network-name", "pass-to-network", 1);
+  #if defined(CONFIG_IDF_TARGET_ESP32S3)
+    // Allow the S3 Wi-Fi task to apply channel 1 before disconnecting.
+    delay(10);
+  #endif
   WiFi.disconnect();
 
   // Soft-set the MAC address to the passphrase UID for binding


### PR DESCRIPTION
Add an S3-only 10 ms delay before disconnecting Wi-Fi, allowing station and channel setup to complete. The ESP-NOW diagnostic receiver already uses the same settling delay.

This resolves ESP-NOW telemetry reception on the MFD Crossbow ESP32-S3 target. The classic ESP32 target works without the delay and remains unchanged.

Other S3 VRX targets using Vrx_main.cpp may also benefit, although only the MFD Crossbow configuration has been hardware-tested.