### PR TITLE
Broadcast VRx-initiated channel changes over ESP-NOW

### DIFF
--- a/src/module_base.cpp
+++ b/src/module_base.cpp
@@ -159,6 +159,21 @@ MSPModuleBase::Loop(uint32_t now)
                 ptrChannelData[2] = packet->payload[4] + (packet->payload[5] << 8);
                 sendMSPViaEspnow(packet);
             }
+            else if (packet->function == MSP_ELRS_BACKPACK_SET_CHANNEL_INDEX &&
+                     packet->type == MSP_PACKET_COMMAND &&
+                     packet->payloadSize >= 1 && packet->payload[0] < 48)
+            {
+                // VRx-initiated channel change (e.g. HDZero goggles "Send VTX"):
+                // rebroadcast over ESP-NOW as MSP_SET_VTX_CONFIG, the opcode
+                // peers act on over the air; 0x0301 is only a UART opcode and
+                // is dropped as unknown by ESP-NOW receivers.
+                mspPacket_t out;
+                out.reset();
+                out.makeCommand();
+                out.function = MSP_SET_VTX_CONFIG;
+                out.addByte(packet->payload[0]);
+                sendMSPViaEspnow(&out);
+            }
             msp.markPacketReceived();
         }
     }


### PR DESCRIPTION
## Summary

When the goggles send `MSP_ELRS_BACKPACK_SET_CHANNEL_INDEX` (0x0301) up the UART (e.g. HDZero goggles "Send VTX" / a channel change made on the goggles), the VRX backpack currently drops it — the UART dispatch in `MSPModuleBase::Loop` only handles `SET_MODE`, `GET_VERSION`, `GET_STATUS` and `SET_PTR`.

This PR forwards it over ESP-NOW as `MSP_SET_VTX_CONFIG` (89), the opcode peers already act on over the air:

- **VRX backpacks** in the bind group retune their goggles (existing `MSP_SET_VTX_CONFIG` handling in `Vrx_main.cpp`).
- **TX backpacks** already pass `MSP_SET_VTX_CONFIG` from a peer straight to the handset (`ProcessMSPPacketFromPeer` in `Tx_main.cpp`, added in #95), so VTX admin can follow the goggle channel and retune the quad's VTX.

No TX-side changes are required.

## Details

- Only acts on `MSP_PACKET_COMMAND` packets with a valid 48-entry table index (`payload[0] < 48`).
- 0x0301 is a UART-only opcode and is dropped as unknown by ESP-NOW receivers, hence the re-packaging as `MSP_SET_VTX_CONFIG` rather than forwarding the packet as-is.
- No echo/loop risk: the goggles send no response to 0x0301, a sender does not receive its own ESP-NOW transmission, the TX backpack's peer handler forwards to Serial only (does not rebroadcast), and VRX receivers dedup an unchanged channel index.

## Testing

Tested with HDZero Goggles 2 (VRX backpack) + RadioMaster Boxer (TX backpack): changing channel on the goggles updates the other bound goggles and the handset's VTX admin channel.
