### PR TITLE
TX: fall back to broadcast when telemetry unicasts are not acknowledged

### DIFF
--- a/src/Tx_main.cpp
+++ b/src/Tx_main.cpp
@@ -40,6 +40,21 @@ unsigned long rebootTime = 0;
 bool cacheFull = false;
 bool sendCached = false;
 
+// Telemetry delivery: a unicast to the UID address expects an 802.11 ACK from a
+// peer carrying that MAC (a bound VRX backpack). When no such peer is present
+// or it is out of range, the WiFi stack retransmits every frame several times;
+// while those retries run, esp_now_send() fails for the telemetry frames that
+// keep arriving from the TX module (up to ~60 frames/s with a CRSF flight
+// controller) and most of the stream is dropped. OnDataSent() counts unacked
+// unicasts; after TLM_UNICAST_FAIL_LIMIT in a row telemetry is sent as
+// broadcast, which goes out exactly once. Every TLM_UNICAST_PROBE_INTERVAL
+// frames one unicast is tried, so a peer coming back switches us to unicast.
+constexpr uint8_t TLM_UNICAST_FAIL_LIMIT = 8;
+constexpr uint8_t TLM_UNICAST_PROBE_INTERVAL = 128;
+volatile uint8_t tlmUnicastFailures = 0;
+volatile bool tlmUseBroadcast = false;
+uint8_t tlmBroadcastCount = 0;
+
 device_t *ui_devices[] = {
 #ifdef PIN_LED
   &LED_device,
@@ -109,6 +124,37 @@ void ProcessMSPPacketFromPeer(mspPacket_t *packet)
       DBGLN("MSP_SET_VTX_CONFIG...");
       msp.sendPacket(packet, &Serial);
       break;
+    }
+  }
+}
+
+// espnow on-send callback: tracks whether unicasts to the UID address get
+// acknowledged, see the telemetry delivery note above
+#if defined(PLATFORM_ESP8266)
+void OnDataSent(uint8_t *mac_addr, uint8_t status)
+{
+  const bool success = status == 0;
+#elif defined(PLATFORM_ESP32)
+void OnDataSent(const uint8_t *mac_addr, esp_now_send_status_t status)
+{
+  const bool success = status == ESP_NOW_SEND_SUCCESS;
+#endif
+  // Only unicasts carry ACK information; broadcasts always report success
+  if (memcmp(mac_addr, firmwareOptions.uid, 6) != 0)
+  {
+    return;
+  }
+  if (success)
+  {
+    tlmUnicastFailures = 0;
+    tlmUseBroadcast = false;
+  }
+  else if (tlmUnicastFailures < TLM_UNICAST_FAIL_LIMIT)
+  {
+    tlmUnicastFailures++;
+    if (tlmUnicastFailures == TLM_UNICAST_FAIL_LIMIT)
+    {
+      tlmUseBroadcast = true;
     }
   }
 }
@@ -285,6 +331,20 @@ void sendMSPViaEspnow(mspPacket_t *packet)
   {
     esp_now_send(bindingAddress, (uint8_t *) &nowDataOutput, packetSize); // Send Bind packet with the broadcast address
   }
+  else if (packet->function == MSP_ELRS_BACKPACK_CRSF_TLM && tlmUseBroadcast)
+  {
+    // Nobody acknowledges our unicasts: send telemetry as broadcast (no ACK,
+    // no retries) and probe with a unicast now and then, see OnDataSent()
+    if (++tlmBroadcastCount >= TLM_UNICAST_PROBE_INTERVAL)
+    {
+      tlmBroadcastCount = 0;
+      esp_now_send(firmwareOptions.uid, (uint8_t *) &nowDataOutput, packetSize);
+    }
+    else
+    {
+      esp_now_send(bindingAddress, (uint8_t *) &nowDataOutput, packetSize);
+    }
+  }
   else
   {
     esp_now_send(firmwareOptions.uid, (uint8_t *) &nowDataOutput, packetSize);
@@ -442,6 +502,7 @@ void setup()
     #endif
 
     esp_now_register_recv_cb(OnDataRecv);
+    esp_now_register_send_cb(OnDataSent);
   }
 
   devicesStart();


### PR DESCRIPTION
### Problem

`sendMSPViaEspnow()` sends every `MSP_ELRS_BACKPACK_CRSF_TLM` frame as a unicast to `firmwareOptions.uid`. A unicast expects an 802.11 ACK from a device carrying that MAC, i.e. a bound VRX backpack. Whenever no such peer is present (VRX switched off, telemetry consumed by a passive listener such as a ground station) or the peer is out of range, the WiFi stack retransmits each frame several times. While those retries run, `esp_now_send()` fails for the frames that keep arriving from the TX module at up to ~60 frames/s (CRSF flight controller), and because the return value is not checked the loss is silent. The retries also occupy 2.4 GHz right next to the ELRS TX module for nothing, and other MSP traffic queued behind them (VTX, head tracking) is delayed or dropped as well.

Measured with an iNav flight controller, RadioMaster TX16S internal ExpressLRS 2.4 GHz module with its stock ESP8285 TX backpack, 500 Hz packet rate, telemetry ratio 1:4, 1 m between TX and a listening ESP32-S3:

| | GPS frames arriving at the listener | max. age of the last GPS position |
|---|---|---|
| listener without ACK (unicast, no peer) | ~3.3 Hz of 10 Hz sent | 1180 ms |
| listener acknowledging the UID MAC | 8.7 Hz (link limit) | 113 ms |

### Change

- Register an ESP-NOW send callback (as `Timer_main.cpp` already does) and count unacknowledged unicasts to the UID address.
- After 8 failures in a row, telemetry frames are sent to the broadcast address instead. A broadcast goes out exactly once, no ACK, no retry, no send-queue stall.
- Every 128 telemetry frames one unicast is tried; as soon as it is acknowledged, delivery returns to unicast. Any other acknowledged unicast (VTX, head tracking) does the same.
- Bind packets already use the broadcast address; all other MSP traffic stays unicast.

Behaviour for existing setups is unchanged: a bound VRX backpack acknowledges every unicast, the failure counter never reaches the limit, and delivery stays unicast. If the VRX is off or out of range, the backpack stops retransmitting into the void. VRX backpacks accept packets by comparing the **sender** MAC with the UID (`Vrx_main.cpp`) and ESP-NOW receivers get broadcast frames without a peer entry, so a VRX switched on later receives the broadcast telemetry immediately and the next probe brings the link back to unicast.

### Testing

- ESP32-S3 listener in promiscuous mode counting 802.11 sequence numbers and the retry bit: with the current firmware and no acknowledging peer, retries on nearly every frame and about two thirds of the GPS frames never sent; with an acknowledging peer 0 missed frames over 30 s.
- RadioMaster TX16S internal 2.4 GHz module with its stock ESP8285 TX backpack, iNav flight controller, 500 Hz, telemetry ratio 1:4.
- Builds for `ESP_TX_Backpack_via_UART` (ESP8266) and `DEBUG_ESP32_TX_Backpack_via_UART` (ESP32).
- Bind already sends to `bindingAddress` on both platforms, so broadcast transmission is a known-good path.
